### PR TITLE
Correctly parse byte literals like `b'a'`

### DIFF
--- a/src/stable.rs
+++ b/src/stable.rs
@@ -311,9 +311,9 @@ named!(token_kind -> TokenKind, alt!(
         TokenKind::Sequence(d, ::TokenStream(s))
     })
     |
-    map!(symbol, |w| TokenKind::Word(::Symbol(w)))
+    map!(literal, |l| TokenKind::Literal(::Literal(l))) // must be before symbol
     |
-    map!(literal, |l| TokenKind::Literal(::Literal(l)))
+    map!(symbol, |w| TokenKind::Word(::Symbol(w)))
     |
     map!(op, |(op, kind): (char, OpKind)| {
         TokenKind::Op(op, kind)


### PR DESCRIPTION
Right now we're parsing them as `Word(b), Literal('a')` instead of `Literal(b'a')`.