### PR TITLE
Derive Eq and PartialEq on OpKind and Delimiter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@ pub enum TokenKind {
     Literal(Literal),
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Delimiter {
     Parenthesis,
     Brace,
@@ -148,7 +148,7 @@ impl Symbol {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum OpKind {
     Alone,
     Joint,


### PR DESCRIPTION
These derives will be available in the final `proc-macro`: https://github.com/rust-lang/rust/pull/40939#issuecomment-304751757.