### PR TITLE
Remove Send and Sync for Symbol

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,15 @@ sudo: false
 before_script:
   - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
 script:
-  - cargo test
+  - travis-cargo build
+  - travis-cargo --only nightly test
   - cargo doc --no-deps
 after_success:
   - travis-cargo --only nightly doc-upload
 env:
   global:
-    secure: "NAsZghAVTAksrm4WP4I66VmD2wW0eRbwB+ZKHUQfvbgUaCRvVdp4WBbWXGU/f/yHgDFWZwljWR4iPMiBwAK8nZsQFRuLFdHrOOHqbkj639LLdT9A07s1zLMB1GfR1fDttzrGhm903pbT2yxSyqqpahGYM7TaGDYYmKYIk4XyVNA5F5Sk7RI+rCecKraoYDeUEFbjWWYtU2FkEXsELEKj0emX5reWkR+wja3QokFcRZ25+Zd2dRC0K8W5QcY2UokLzKncBMCTC5q70H616S3r/9qW67Si1njsJ7RzP0NlZQUNQ/VCvwr4LCr9w+AD9i1SZtXxuux77tWEWSJvBzUc82dDMUv/floJuF7HTulSxxQoRm+fbzpXj9mgaJNiUHXru6ZRTCRVRUSXpcAco94bVoy/jnjrTe3jgAIZK5w14zA8yLw1Jxof31DlbcWORxgF+6fnY2nKPRN2oiQ50+jm1AuGDZX59/wMiu1QlkjOBHtikHp+u+7mp3SkkM04DvuQ/tWODQQnOOtrA0EB3i5H1zeTSnUcmbJufUljWWOvF1QYII08MccqwfG1KWbpobvdu+cV2iVhkq/lNCEL3Ai101CnmSCnMz+9oK/XxYOrx2TnaD9ootOKgnk7XWxF19GZecQx6O2hHTouxvB/0KcRPGWmMWl0H88f3T/Obql8bG8="
+    - TRAVIS_CARGO_NIGHTLY_FEATURE=""
+    - secure: "NAsZghAVTAksrm4WP4I66VmD2wW0eRbwB+ZKHUQfvbgUaCRvVdp4WBbWXGU/f/yHgDFWZwljWR4iPMiBwAK8nZsQFRuLFdHrOOHqbkj639LLdT9A07s1zLMB1GfR1fDttzrGhm903pbT2yxSyqqpahGYM7TaGDYYmKYIk4XyVNA5F5Sk7RI+rCecKraoYDeUEFbjWWYtU2FkEXsELEKj0emX5reWkR+wja3QokFcRZ25+Zd2dRC0K8W5QcY2UokLzKncBMCTC5q70H616S3r/9qW67Si1njsJ7RzP0NlZQUNQ/VCvwr4LCr9w+AD9i1SZtXxuux77tWEWSJvBzUc82dDMUv/floJuF7HTulSxxQoRm+fbzpXj9mgaJNiUHXru6ZRTCRVRUSXpcAco94bVoy/jnjrTe3jgAIZK5w14zA8yLw1Jxof31DlbcWORxgF+6fnY2nKPRN2oiQ50+jm1AuGDZX59/wMiu1QlkjOBHtikHp+u+7mp3SkkM04DvuQ/tWODQQnOOtrA0EB3i5H1zeTSnUcmbJufUljWWOvF1QYII08MccqwfG1KWbpobvdu+cV2iVhkq/lNCEL3Ai101CnmSCnMz+9oK/XxYOrx2TnaD9ootOKgnk7XWxF19GZecQx6O2hHTouxvB/0KcRPGWmMWl0H88f3T/Obql8bG8="
 
 notifications:
   email:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,8 @@ doctest = false
 [dependencies]
 unicode-xid = "0.0.4"
 
+[dev-dependencies]
+compiletest_rs = "0.2"
+
 [features]
 unstable = []

--- a/tests/compile-fail/symbol_send.rs
+++ b/tests/compile-fail/symbol_send.rs
@@ -1,0 +1,9 @@
+extern crate proc_macro2;
+
+use proc_macro2::Symbol;
+
+fn assert_send<T: Send>() {}
+
+fn main() {
+    assert_send::<Symbol>(); //~ the trait bound `*const (): std::marker::Send` is not satisfied in `proc_macro2::Symbol`
+}

--- a/tests/compile-fail/symbol_sync.rs
+++ b/tests/compile-fail/symbol_sync.rs
@@ -1,0 +1,9 @@
+extern crate proc_macro2;
+
+use proc_macro2::Symbol;
+
+fn assert_sync<T: Sync>() {}
+
+fn main() {
+    assert_sync::<Symbol>(); //~ the trait bound `*const (): std::marker::Sync` is not satisfied in `proc_macro2::Symbol`
+}

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -1,0 +1,14 @@
+extern crate compiletest_rs as compiletest;
+
+fn run_mode(mode: &'static str) {
+    let mut config = compiletest::default_config();
+    config.mode = mode.parse().expect("invalid mode");
+    config.target_rustcflags = Some("-L target/debug/deps".to_owned());
+    config.src_base = format!("tests/{}", mode).into();
+    compiletest::run_tests(&config);
+}
+
+#[test]
+fn compile_fail() {
+    run_mode("compile-fail");
+}


### PR DESCRIPTION
Fixes #24.

I don't know how to write a test for this. Any ideas? :cry: 

I tried this but the impls conflict:

```rust
trait NotSend {}
impl<T> NotSend for T where T: Send {}

// Would fail if Symbol is Send
impl NotSend for Symbol {}
```