### PR TITLE
Derive `Eq/PartialEq` for `Spacing`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,7 +165,7 @@ impl Term {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Spacing {
     Alone,
     Joint,


### PR DESCRIPTION
I don't see a reason why it shouldn't be `Eq`/`PartialEq`... but I hardly know anything about proc macros, so I'm probably wrong ^_^