### PR TITLE
Support meaningful spans in the stable version of proc-macro2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,15 @@ matrix:
       script:
         - cargo test
         - cargo build --features unstable
-        - cargo doc --no-deps
+        - RUSTFLAGS='--cfg procmacro2_unstable' cargo test
+        - RUSTFLAGS='--cfg procmacro2_unstable' cargo build --features unstable
+        - RUSTFLAGS='--cfg procmacro2_unstable' cargo doc --no-deps
       after_success:
         - travis-cargo --only nightly doc-upload
 
 script:
   - cargo test
+  - RUSTFLAGS='--cfg procmacro2_unstable' cargo test
 env:
   global:
     - TRAVIS_CARGO_NIGHTLY_FEATURE=""

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ doctest = false
 
 [dependencies]
 unicode-xid = "0.1"
-memchr = "2.0"
 
 [features]
 unstable = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ doctest = false
 
 [dependencies]
 unicode-xid = "0.1"
+memchr = "2.0"
 
 [features]
 unstable = []

--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ proc-macro2 = { version = "0.1", features = ["unstable"] }
 ```
 
 
+## Unstable Features
+
+`proc-macro2` supports exporting some methods from `proc_macro` which are
+currently highly unstable, and may not be stabilized in the first pass of
+`proc_macro` stabilizations. These features are not exported by default.
+
+To export these features, the `procmacro2_unstable` config flag must be passed
+to rustc. To pass this flag, run `cargo` with 
+`RUSTFLAGS='--cfg procmacro2_unstable' cargo build`.
+
+
 # License
 
 This project is licensed under either of

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,10 @@ impl fmt::Debug for SourceFile {
 // NOTE: We can't easily wrap LineColumn right now, as the version in proc-macro
 // doesn't actually expose the internal `line` and `column` fields, making it
 // mostly useless.
-pub use imp::LineColumn;
+pub struct LineColumn {
+    pub line: usize,
+    pub column: usize,
+}
 
 #[derive(Copy, Clone)]
 pub struct Span(imp::Span);
@@ -167,13 +170,13 @@ impl Span {
     }
 
     pub fn start(&self) -> LineColumn {
-        // XXX(nika): We can't easily wrap LineColumn right now
-        self.0.start()
+        let imp::LineColumn{ line, column } = self.0.start();
+        LineColumn { line, column }
     }
 
     pub fn end(&self) -> LineColumn {
-        // XXX(nika): We can't easily wrap LineColumn right now
-        self.0.end()
+        let imp::LineColumn{ line, column } = self.0.end();
+        LineColumn { line, column }
     }
 
     pub fn join(&self, other: Span) -> Option<Span> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,11 +107,14 @@ impl TokenStream {
 }
 
 // Returned by reference, so we can't easily wrap it.
+#[cfg(procmacro2_unstable)]
 pub use imp::FileName;
 
+#[cfg(procmacro2_unstable)]
 #[derive(Clone, PartialEq, Eq)]
 pub struct SourceFile(imp::SourceFile);
 
+#[cfg(procmacro2_unstable)]
 impl SourceFile {
     /// Get the path to this source file as a string.
     pub fn path(&self) -> &FileName {
@@ -123,18 +126,21 @@ impl SourceFile {
     }
 }
 
+#[cfg(procmacro2_unstable)]
 impl AsRef<FileName> for SourceFile {
     fn as_ref(&self) -> &FileName {
         self.0.path()
     }
 }
 
+#[cfg(procmacro2_unstable)]
 impl fmt::Debug for SourceFile {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt(f)
     }
 }
 
+#[cfg(procmacro2_unstable)]
 pub struct LineColumn {
     pub line: usize,
     pub column: usize,
@@ -159,20 +165,24 @@ impl Span {
         Span(imp::Span::def_site())
     }
 
+    #[cfg(procmacro2_unstable)]
     pub fn source_file(&self) -> SourceFile {
         SourceFile(self.0.source_file())
     }
 
+    #[cfg(procmacro2_unstable)]
     pub fn start(&self) -> LineColumn {
         let imp::LineColumn{ line, column } = self.0.start();
         LineColumn { line, column }
     }
 
+    #[cfg(procmacro2_unstable)]
     pub fn end(&self) -> LineColumn {
         let imp::LineColumn{ line, column } = self.0.end();
         LineColumn { line, column }
     }
 
+    #[cfg(procmacro2_unstable)]
     pub fn join(&self, other: Span) -> Option<Span> {
         self.0.join(other.0).map(Span)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,13 +106,16 @@ impl TokenStream {
     }
 }
 
+// Returned by reference, so we can't easily wrap it.
+pub use imp::FileName;
+
 #[derive(Clone, PartialEq, Eq)]
 pub struct SourceFile(imp::SourceFile);
 
 impl SourceFile {
     /// Get the path to this source file as a string.
-    pub fn as_str(&self) -> &str {
-        self.0.as_str()
+    pub fn path(&self) -> &FileName {
+        self.0.path()
     }
 
     pub fn is_real(&self) -> bool {
@@ -120,15 +123,9 @@ impl SourceFile {
     }
 }
 
-impl AsRef<str> for SourceFile {
-    fn as_ref(&self) -> &str {
-        self.0.as_ref()
-    }
-}
-
-impl PartialEq<str> for SourceFile {
-    fn eq(&self, other: &str) -> bool {
-        self.0.eq(other)
+impl AsRef<FileName> for SourceFile {
+    fn as_ref(&self) -> &FileName {
+        self.0.path()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,9 +135,6 @@ impl fmt::Debug for SourceFile {
     }
 }
 
-// NOTE: We can't easily wrap LineColumn right now, as the version in proc-macro
-// doesn't actually expose the internal `line` and `column` fields, making it
-// mostly useless.
 pub struct LineColumn {
     pub line: usize,
     pub column: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,9 +24,6 @@
 extern crate proc_macro;
 
 #[cfg(not(feature = "unstable"))]
-extern crate memchr;
-
-#[cfg(not(feature = "unstable"))]
 extern crate unicode_xid;
 
 use std::fmt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,9 @@
 extern crate proc_macro;
 
 #[cfg(not(feature = "unstable"))]
+extern crate memchr;
+
+#[cfg(not(feature = "unstable"))]
 extern crate unicode_xid;
 
 use std::fmt;
@@ -103,6 +106,43 @@ impl TokenStream {
     }
 }
 
+#[derive(Clone, PartialEq, Eq)]
+pub struct SourceFile(imp::SourceFile);
+
+impl SourceFile {
+    /// Get the path to this source file as a string.
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    pub fn is_real(&self) -> bool {
+        self.0.is_real()
+    }
+}
+
+impl AsRef<str> for SourceFile {
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
+impl PartialEq<str> for SourceFile {
+    fn eq(&self, other: &str) -> bool {
+        self.0.eq(other)
+    }
+}
+
+impl fmt::Debug for SourceFile {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+// NOTE: We can't easily wrap LineColumn right now, as the version in proc-macro
+// doesn't actually expose the internal `line` and `column` fields, making it
+// mostly useless.
+pub use imp::LineColumn;
+
 #[derive(Copy, Clone)]
 pub struct Span(imp::Span);
 
@@ -120,6 +160,24 @@ impl Span {
 
     pub fn def_site() -> Span {
         Span(imp::Span::def_site())
+    }
+
+    pub fn source_file(&self) -> SourceFile {
+        SourceFile(self.0.source_file())
+    }
+
+    pub fn start(&self) -> LineColumn {
+        // XXX(nika): We can't easily wrap LineColumn right now
+        self.0.start()
+    }
+
+    pub fn end(&self) -> LineColumn {
+        // XXX(nika): We can't easily wrap LineColumn right now
+        self.0.end()
+    }
+
+    pub fn join(&self, other: Span) -> Option<Span> {
+        self.0.join(other.0).map(Span)
     }
 }
 

--- a/src/stable.rs
+++ b/src/stable.rs
@@ -150,14 +150,23 @@ impl IntoIterator for TokenStream {
     }
 }
 
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct FileName(String);
+
+impl fmt::Display for FileName {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 #[derive(Clone, PartialEq, Eq)]
 pub struct SourceFile {
-    name: String,
+    name: FileName,
 }
 
 impl SourceFile {
     /// Get the path to this source file as a string.
-    pub fn as_str(&self) -> &str {
+    pub fn path(&self) -> &FileName {
         &self.name
     }
 
@@ -167,22 +176,16 @@ impl SourceFile {
     }
 }
 
-impl AsRef<str> for SourceFile {
-    fn as_ref(&self) -> &str {
-        self.as_str()
-    }
-}
-
-impl PartialEq<str> for SourceFile {
-    fn eq(&self, other: &str) -> bool {
-        self.as_ref() == other
+impl AsRef<FileName> for SourceFile {
+    fn as_ref(&self) -> &FileName {
+        self.path()
     }
 }
 
 impl fmt::Debug for SourceFile {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("SourceFile")
-            .field("path", &self.as_str())
+            .field("path", &self.path())
             .field("is_real", &self.is_real())
             .finish()
     }
@@ -299,7 +302,7 @@ impl Span {
             let cm = cm.borrow();
             let fi = cm.fileinfo(*self);
             SourceFile {
-                name: fi.name.clone(),
+                name: FileName(fi.name.clone()),
             }
         })
     }

--- a/src/stable.rs
+++ b/src/stable.rs
@@ -1,6 +1,7 @@
 use std::ascii;
 use std::borrow::Borrow;
 use std::cell::RefCell;
+use std::cmp;
 use std::collections::HashMap;
 use std::fmt;
 use std::iter;
@@ -10,9 +11,10 @@ use std::rc::Rc;
 use std::str::FromStr;
 use std::vec;
 
+use memchr;
 use proc_macro;
 use unicode_xid::UnicodeXID;
-use strnom::{PResult, skip_whitespace, block_comment, whitespace, word_break};
+use strnom::{Cursor, PResult, skip_whitespace, block_comment, whitespace, word_break};
 
 use {TokenTree, TokenNode, Delimiter, Spacing};
 
@@ -38,7 +40,18 @@ impl FromStr for TokenStream {
     type Err = LexError;
 
     fn from_str(src: &str) -> Result<TokenStream, LexError> {
-        match token_stream(src) {
+        // Create a dummy file & add it to the codemap
+        let cursor = CODEMAP.with(|cm| {
+            let mut cm = cm.borrow_mut();
+            let name = format!("<parsed string {}>", cm.files.len());
+            let span = cm.add_file(&name, src);
+            Cursor {
+                rest: src,
+                off: span.lo,
+            }
+        });
+
+        match token_stream(cursor) {
             Ok((input, output)) => {
                 if skip_whitespace(input).len() != 0 {
                     Err(LexError)
@@ -137,16 +150,188 @@ impl IntoIterator for TokenStream {
     }
 }
 
+#[derive(Clone, PartialEq, Eq)]
+pub struct SourceFile {
+    name: String,
+}
+
+impl SourceFile {
+    /// Get the path to this source file as a string.
+    pub fn as_str(&self) -> &str {
+        &self.name
+    }
+
+    pub fn is_real(&self) -> bool {
+        // XXX(nika): Support real files in the future?
+        false
+    }
+}
+
+impl AsRef<str> for SourceFile {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl PartialEq<str> for SourceFile {
+    fn eq(&self, other: &str) -> bool {
+        self.as_ref() == other
+    }
+}
+
+impl fmt::Debug for SourceFile {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("SourceFile")
+            .field("path", &self.as_str())
+            .field("is_real", &self.is_real())
+            .finish()
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LineColumn {
+    pub line: usize,
+    pub column: usize,
+}
+
+thread_local! {
+    static CODEMAP: RefCell<Codemap> = RefCell::new(Codemap {
+        // NOTE: We start with a single dummy file which all call_site() and
+        // def_site() spans reference.
+        files: vec![FileInfo {
+            name: "<unspecified>".to_owned(),
+            span: Span { lo: 0, hi: 0 },
+            lines: vec![0],
+        }],
+    });
+}
+
+struct FileInfo {
+    name: String,
+    span: Span,
+    lines: Vec<usize>,
+}
+
+impl FileInfo {
+    fn offset_line_column(&self, offset: usize) -> LineColumn {
+        assert!(self.span_within(Span { lo: offset as u32, hi: offset as u32 }));
+        let offset = offset - self.span.lo as usize;
+        match self.lines.binary_search(&offset) {
+            Ok(found) => LineColumn {
+                line: found + 1,
+                column: 0
+            },
+            Err(idx) => LineColumn {
+                line: idx,
+                column: offset - self.lines[idx - 1]
+            },
+        }
+    }
+
+    fn span_within(&self, span: Span) -> bool {
+        span.lo >= self.span.lo && span.hi <= self.span.hi
+    }
+}
+
+/// Computes the offsets of each line in the given source string.
+fn lines_offsets(s: &[u8]) -> Vec<usize> {
+    let mut lines = vec![0];
+    let mut prev = 0;
+    while let Some(len) = memchr::memchr(b'\n', &s[prev..]) {
+        prev += len + 1;
+        lines.push(prev);
+    }
+    lines
+}
+
+struct Codemap {
+    files: Vec<FileInfo>,
+}
+
+impl Codemap {
+    fn next_start_pos(&self) -> u32 {
+        // Add 1 so there's always space between files.
+        //
+        // We'll always have at least 1 file, as we initialize our files list
+        // with a dummy file.
+        self.files.last().unwrap().span.hi + 1
+    }
+
+    fn add_file(&mut self, name: &str, src: &str) -> Span {
+        let lines = lines_offsets(src.as_bytes());
+        let lo = self.next_start_pos();
+        // XXX(nika): Shouild we bother doing a checked cast or checked add here?
+        let span = Span { lo: lo, hi: lo + (src.len() as u32) };
+
+        self.files.push(FileInfo {
+            name: name.to_owned(),
+            span: span,
+            lines: lines,
+        });
+
+        span
+    }
+
+    fn fileinfo(&self, span: Span) -> &FileInfo {
+        for file in &self.files {
+            if file.span_within(span) {
+                return file;
+            }
+        }
+        panic!("Invalid span with no related FileInfo!");
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
-pub struct Span;
+pub struct Span { lo: u32, hi: u32 }
 
 impl Span {
     pub fn call_site() -> Span {
-        Span
+        Span { lo: 0, hi: 0 }
     }
 
     pub fn def_site() -> Span {
-        Span
+        Span { lo: 0, hi: 0 }
+    }
+
+    pub fn source_file(&self) -> SourceFile {
+        CODEMAP.with(|cm| {
+            let cm = cm.borrow();
+            let fi = cm.fileinfo(*self);
+            SourceFile {
+                name: fi.name.clone(),
+            }
+        })
+    }
+
+    pub fn start(&self) -> LineColumn {
+        CODEMAP.with(|cm| {
+            let cm = cm.borrow();
+            let fi = cm.fileinfo(*self);
+            fi.offset_line_column(self.lo as usize)
+        })
+    }
+
+    pub fn end(&self) -> LineColumn {
+        CODEMAP.with(|cm| {
+            let cm = cm.borrow();
+            let fi = cm.fileinfo(*self);
+            fi.offset_line_column(self.hi as usize)
+        })
+    }
+
+    pub fn join(&self, other: Span) -> Option<Span> {
+        CODEMAP.with(|cm| {
+            let cm = cm.borrow();
+            // If `other` is not within the same FileInfo as us, return None.
+            if !cm.fileinfo(*self).span_within(other) {
+                return None;
+            }
+            Some(Span {
+                lo: cmp::min(self.lo, other.lo),
+                hi: cmp::max(self.hi, other.hi),
+            })
+        })
     }
 }
 
@@ -349,13 +534,19 @@ named!(token_stream -> ::TokenStream, map!(
     |trees| ::TokenStream(TokenStream { inner: trees })
 ));
 
-named!(token_tree -> TokenTree,
-       map!(token_kind, |s: TokenNode| {
-           TokenTree {
-               span: ::Span(Span),
-               kind: s,
-           }
-       }));
+fn token_tree(input: Cursor) -> PResult<TokenTree> {
+    let input = skip_whitespace(input);
+    let lo = input.off;
+    let (input, kind) = token_kind(input)?;
+    let hi = input.off;
+    Ok((input, TokenTree {
+        span: ::Span(Span {
+            lo: lo,
+            hi: hi,
+        }),
+        kind: kind,
+    }))
+}
 
 named!(token_kind -> TokenNode, alt!(
     map!(delimited, |(d, s)| TokenNode::Group(d, s))
@@ -387,7 +578,7 @@ named!(delimited -> (Delimiter, ::TokenStream), alt!(
     ) => { |ts| (Delimiter::Brace, ts) }
 ));
 
-fn symbol(mut input: &str) -> PResult<TokenNode> {
+fn symbol(mut input: Cursor) -> PResult<TokenNode> {
     input = skip_whitespace(input);
 
     let mut chars = input.char_indices();
@@ -410,14 +601,14 @@ fn symbol(mut input: &str) -> PResult<TokenNode> {
         }
     }
 
-    if lifetime && &input[..end] != "'static" && KEYWORDS.contains(&&input[1..end]) {
+    if lifetime && &input.rest[..end] != "'static" && KEYWORDS.contains(&&input.rest[1..end]) {
         Err(LexError)
     } else {
-        let (a, b) = input.split_at(end);
+        let a = &input.rest[..end];
         if a == "_" {
-            Ok((b, TokenNode::Op('_', Spacing::Alone)))
+            Ok((input.advance(end), TokenNode::Op('_', Spacing::Alone)))
         } else {
-            Ok((b, TokenNode::Term(::Term::intern(a))))
+            Ok((input.advance(end), TokenNode::Term(::Term::intern(a))))
         }
     }
 }
@@ -433,7 +624,7 @@ static KEYWORDS: &'static [&'static str] = &[
     "yield",
 ];
 
-fn literal(input: &str) -> PResult<::Literal> {
+fn literal(input: Cursor) -> PResult<::Literal> {
     let input_no_ws = skip_whitespace(input);
 
     match literal_nocapture(input_no_ws) {
@@ -441,7 +632,7 @@ fn literal(input: &str) -> PResult<::Literal> {
             let start = input.len() - input_no_ws.len();
             let len = input_no_ws.len() - a.len();
             let end = start + len;
-            Ok((a, ::Literal(Literal(input[start..end].to_string()))))
+            Ok((a, ::Literal(Literal(input.rest[start..end].to_string()))))
         }
         Err(LexError) => Err(LexError),
     }
@@ -480,12 +671,12 @@ named!(quoted_string -> (), delimited!(
     tag!("\"")
 ));
 
-fn cooked_string(input: &str) -> PResult<()> {
+fn cooked_string(input: Cursor) -> PResult<()> {
     let mut chars = input.char_indices().peekable();
     while let Some((byte_offset, ch)) = chars.next() {
         match ch {
             '"' => {
-                return Ok((&input[byte_offset..], ()));
+                return Ok((input.advance(byte_offset), ()));
             }
             '\r' => {
                 if let Some((_, '\n')) = chars.next() {
@@ -544,12 +735,12 @@ named!(byte_string -> (), alt!(
     ) => { |_| () }
 ));
 
-fn cooked_byte_string(mut input: &str) -> PResult<()> {
+fn cooked_byte_string(mut input: Cursor) -> PResult<()> {
     let mut bytes = input.bytes().enumerate();
     'outer: while let Some((offset, b)) = bytes.next() {
         match b {
             b'"' => {
-                return Ok((&input[offset..], ()));
+                return Ok((input.advance(offset), ()));
             }
             b'\r' => {
                 if let Some((_, b'\n')) = bytes.next() {
@@ -574,10 +765,10 @@ fn cooked_byte_string(mut input: &str) -> PResult<()> {
                     Some((_, b'"'))  => {}
                     Some((newline, b'\n')) |
                     Some((newline, b'\r')) => {
-                        let rest = &input[newline + 1..];
+                        let rest = input.advance(newline + 1);
                         for (offset, ch) in rest.char_indices() {
                             if !ch.is_whitespace() {
-                                input = &rest[offset..];
+                                input = rest.advance(offset);
                                 bytes = input.bytes().enumerate();
                                 continue 'outer;
                             }
@@ -594,7 +785,7 @@ fn cooked_byte_string(mut input: &str) -> PResult<()> {
     Err(LexError)
 }
 
-fn raw_string(input: &str) -> PResult<()> {
+fn raw_string(input: Cursor) -> PResult<()> {
     let mut chars = input.char_indices();
     let mut n = 0;
     while let Some((byte_offset, ch)) = chars.next() {
@@ -609,8 +800,8 @@ fn raw_string(input: &str) -> PResult<()> {
     }
     for (byte_offset, ch) in chars {
         match ch {
-            '"' if input[byte_offset + 1..].starts_with(&input[..n]) => {
-                let rest = &input[byte_offset + 1 + n..];
+            '"' if input.advance(byte_offset + 1).starts_with(&input.rest[..n]) => {
+                let rest = input.advance(byte_offset + 1 + n);
                 return Ok((rest, ()))
             }
             '\r' => {}
@@ -628,7 +819,7 @@ named!(byte -> (), do_parse!(
     (())
 ));
 
-fn cooked_byte(input: &str) -> PResult<()> {
+fn cooked_byte(input: Cursor) -> PResult<()> {
     let mut bytes = input.bytes().enumerate();
     let ok = match bytes.next().map(|(_, b)| b) {
         Some(b'\\') => {
@@ -648,8 +839,8 @@ fn cooked_byte(input: &str) -> PResult<()> {
     };
     if ok {
         match bytes.next() {
-            Some((offset, _)) => Ok((&input[offset..], ())),
-            None => Ok(("", ())),
+            Some((offset, _)) => Ok((input.advance(offset), ())),
+            None => Ok((input.advance(input.len()), ())),
         }
     } else {
         Err(LexError)
@@ -663,7 +854,7 @@ named!(character -> (), do_parse!(
     (())
 ));
 
-fn cooked_char(input: &str) -> PResult<()> {
+fn cooked_char(input: Cursor) -> PResult<()> {
     let mut chars = input.char_indices();
     let ok = match chars.next().map(|(_, ch)| ch) {
         Some('\\') => {
@@ -683,7 +874,10 @@ fn cooked_char(input: &str) -> PResult<()> {
         ch => ch.is_some(),
     };
     if ok {
-        Ok((chars.as_str(), ()))
+        match chars.next() {
+            Some((idx, _)) => Ok((input.advance(idx), ())),
+            None => Ok((input.advance(input.len()), ())),
+        }
     } else {
         Err(LexError)
     }
@@ -746,17 +940,17 @@ fn backslash_u<I>(chars: &mut I) -> bool
     true
 }
 
-fn float(input: &str) -> PResult<()> {
+fn float(input: Cursor) -> PResult<()> {
     let (rest, ()) = float_digits(input)?;
     for suffix in &["f32", "f64"] {
         if rest.starts_with(suffix) {
-            return word_break(&rest[suffix.len()..]);
+            return word_break(rest.advance(suffix.len()));
         }
     }
     word_break(rest)
 }
 
-fn float_digits(input: &str) -> PResult<()> {
+fn float_digits(input: Cursor) -> PResult<()> {
     let mut chars = input.chars().peekable();
     match chars.next() {
         Some(ch) if ch >= '0' && ch <= '9' => {}
@@ -795,7 +989,7 @@ fn float_digits(input: &str) -> PResult<()> {
         }
     }
 
-    let rest = &input[len..];
+    let rest = input.advance(len);
     if !(has_dot || has_exp || rest.starts_with("f32") || rest.starts_with("f64")) {
         return Err(LexError);
     }
@@ -828,10 +1022,10 @@ fn float_digits(input: &str) -> PResult<()> {
         }
     }
 
-    Ok((&input[len..], ()))
+    Ok((input.advance(len), ()))
 }
 
-fn int(input: &str) -> PResult<()> {
+fn int(input: Cursor) -> PResult<()> {
     let (rest, ()) = digits(input)?;
     for suffix in &[
         "isize",
@@ -848,21 +1042,21 @@ fn int(input: &str) -> PResult<()> {
         "u128",
     ] {
         if rest.starts_with(suffix) {
-            return word_break(&rest[suffix.len()..]);
+            return word_break(rest.advance(suffix.len()));
         }
     }
     word_break(rest)
 }
 
-fn digits(mut input: &str) -> PResult<()> {
+fn digits(mut input: Cursor) -> PResult<()> {
     let base = if input.starts_with("0x") {
-        input = &input[2..];
+        input = input.advance(2);
         16
     } else if input.starts_with("0o") {
-        input = &input[2..];
+        input = input.advance(2);
         8
     } else if input.starts_with("0b") {
-        input = &input[2..];
+        input = input.advance(2);
         2
     } else {
         10
@@ -893,7 +1087,7 @@ fn digits(mut input: &str) -> PResult<()> {
     if empty {
         Err(LexError)
     } else {
-        Ok((&input[len..], ()))
+        Ok((input.advance(len), ()))
     }
 }
 
@@ -903,7 +1097,7 @@ named!(boolean -> (), alt!(
     keyword!("false") => { |_| () }
 ));
 
-fn op(input: &str) -> PResult<(char, Spacing)> {
+fn op(input: Cursor) -> PResult<(char, Spacing)> {
     let input = skip_whitespace(input);
     match op_char(input) {
         Ok((rest, ch)) => {
@@ -917,7 +1111,7 @@ fn op(input: &str) -> PResult<(char, Spacing)> {
     }
 }
 
-fn op_char(input: &str) -> PResult<char> {
+fn op_char(input: Cursor) -> PResult<char> {
     let mut chars = input.chars();
     let first = match chars.next() {
         Some(ch) => ch,
@@ -927,7 +1121,7 @@ fn op_char(input: &str) -> PResult<char> {
     };
     let recognized = "~!@#$%^&*-=+|;:,<.>/?";
     if recognized.contains(first) {
-        Ok((chars.as_str(), first))
+        Ok((input.advance(first.len_utf8()), first))
     } else {
         Err(LexError)
     }

--- a/src/stable.rs
+++ b/src/stable.rs
@@ -12,8 +12,6 @@ use std::rc::Rc;
 use std::str::FromStr;
 use std::vec;
 
-#[cfg(procmacro2_unstable)]
-use memchr;
 use proc_macro;
 use unicode_xid::UnicodeXID;
 use strnom::{Cursor, PResult, skip_whitespace, block_comment, whitespace, word_break};
@@ -264,10 +262,10 @@ impl FileInfo {
 
 /// Computes the offsets of each line in the given source string.
 #[cfg(procmacro2_unstable)]
-fn lines_offsets(s: &[u8]) -> Vec<usize> {
+fn lines_offsets(s: &str) -> Vec<usize> {
     let mut lines = vec![0];
     let mut prev = 0;
-    while let Some(len) = memchr::memchr(b'\n', &s[prev..]) {
+    while let Some(len) = s[prev..].find('\n') {
         prev += len + 1;
         lines.push(prev);
     }
@@ -290,7 +288,7 @@ impl Codemap {
     }
 
     fn add_file(&mut self, name: &str, src: &str) -> Span {
-        let lines = lines_offsets(src.as_bytes());
+        let lines = lines_offsets(src);
         let lo = self.next_start_pos();
         // XXX(nika): Shouild we bother doing a checked cast or checked add here?
         let span = Span { lo: lo, hi: lo + (src.len() as u32) };

--- a/src/unstable.rs
+++ b/src/unstable.rs
@@ -159,6 +159,41 @@ impl fmt::Debug for TokenTreeIter {
     }
 }
 
+#[derive(Clone, PartialEq, Eq)]
+pub struct SourceFile(proc_macro::SourceFile);
+
+impl SourceFile {
+    /// Get the path to this source file as a string.
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    pub fn is_real(&self) -> bool {
+        self.0.is_real()
+    }
+}
+
+impl AsRef<str> for SourceFile {
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
+impl PartialEq<str> for SourceFile {
+    fn eq(&self, other: &str) -> bool {
+        self.0.eq(other)
+    }
+}
+
+impl fmt::Debug for SourceFile {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+// XXX(nika): We can't easily wrap LineColumn right now
+pub use proc_macro::LineColumn;
+
 #[derive(Copy, Clone)]
 pub struct Span(proc_macro::Span);
 
@@ -169,6 +204,24 @@ impl Span {
 
     pub fn def_site() -> Span {
         Span(proc_macro::Span::def_site())
+    }
+
+    pub fn source_file(&self) -> SourceFile {
+        SourceFile(self.0.source_file())
+    }
+
+    pub fn start(&self) -> LineColumn {
+        // XXX(nika): We can't easily wrap LineColumn right now
+        self.0.start()
+    }
+
+    pub fn end(&self) -> LineColumn {
+        // XXX(nika): We can't easily wrap LineColumn right now
+        self.0.end()
+    }
+
+    pub fn join(&self, other: Span) -> Option<Span> {
+        self.0.join(other.0).map(Span)
     }
 }
 

--- a/src/unstable.rs
+++ b/src/unstable.rs
@@ -159,9 +159,11 @@ impl fmt::Debug for TokenTreeIter {
     }
 }
 
+#[cfg(procmacro2_unstable)]
 #[derive(Clone, PartialEq, Eq)]
 pub struct FileName(String);
 
+#[cfg(procmacro2_unstable)]
 impl fmt::Display for FileName {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt(f)
@@ -170,9 +172,11 @@ impl fmt::Display for FileName {
 
 // NOTE: We have to generate our own filename object here because we can't wrap
 // the one provided by proc_macro.
+#[cfg(procmacro2_unstable)]
 #[derive(Clone, PartialEq, Eq)]
 pub struct SourceFile(proc_macro::SourceFile, FileName);
 
+#[cfg(procmacro2_unstable)]
 impl SourceFile {
     fn new(sf: proc_macro::SourceFile) -> Self {
         let filename = FileName(sf.path().to_string());
@@ -189,18 +193,21 @@ impl SourceFile {
     }
 }
 
+#[cfg(procmacro2_unstable)]
 impl AsRef<FileName> for SourceFile {
     fn as_ref(&self) -> &FileName {
         self.path()
     }
 }
 
+#[cfg(procmacro2_unstable)]
 impl fmt::Debug for SourceFile {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt(f)
     }
 }
 
+#[cfg(procmacro2_unstable)]
 pub struct LineColumn {
     pub line: usize,
     pub column: usize,
@@ -218,20 +225,24 @@ impl Span {
         Span(proc_macro::Span::def_site())
     }
 
+    #[cfg(procmacro2_unstable)]
     pub fn source_file(&self) -> SourceFile {
         SourceFile::new(self.0.source_file())
     }
 
+    #[cfg(procmacro2_unstable)]
     pub fn start(&self) -> LineColumn {
         let proc_macro::LineColumn{ line, column } = self.0.start();
         LineColumn { line, column }
     }
 
+    #[cfg(procmacro2_unstable)]
     pub fn end(&self) -> LineColumn {
         let proc_macro::LineColumn{ line, column } = self.0.end();
         LineColumn { line, column }
     }
 
+    #[cfg(procmacro2_unstable)]
     pub fn join(&self, other: Span) -> Option<Span> {
         self.0.join(other.0).map(Span)
     }

--- a/src/unstable.rs
+++ b/src/unstable.rs
@@ -191,8 +191,10 @@ impl fmt::Debug for SourceFile {
     }
 }
 
-// XXX(nika): We can't easily wrap LineColumn right now
-pub use proc_macro::LineColumn;
+pub struct LineColumn {
+    pub line: usize,
+    pub column: usize,
+}
 
 #[derive(Copy, Clone)]
 pub struct Span(proc_macro::Span);
@@ -211,13 +213,13 @@ impl Span {
     }
 
     pub fn start(&self) -> LineColumn {
-        // XXX(nika): We can't easily wrap LineColumn right now
-        self.0.start()
+        let proc_macro::LineColumn{ line, column } = self.0.start();
+        LineColumn { line, column }
     }
 
     pub fn end(&self) -> LineColumn {
-        // XXX(nika): We can't easily wrap LineColumn right now
-        self.0.end()
+        let proc_macro::LineColumn{ line, column } = self.0.end();
+        LineColumn { line, column }
     }
 
     pub fn join(&self, other: Span) -> Option<Span> {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -66,7 +66,6 @@ fn fail() {
 #[test]
 fn span_test() {
     fn check_spans(p: &str, mut lines: &[(usize, usize, usize, usize)]) {
-        eprintln!("checking {:?}", p);
         let ts = p.parse::<TokenStream>().unwrap();
         check_spans_internal(ts, &mut lines);
     }
@@ -78,8 +77,6 @@ fn span_test() {
         for i in ts {
             if let Some((&(sline, scol, eline, ecol), rest)) = lines.split_first() {
                 *lines = rest;
-
-                eprintln!("span = {:?}", i.span);
 
                 let start = i.span.start();
                 assert_eq!(start.line, sline, "sline did not match for {}", i);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -63,6 +63,7 @@ fn fail() {
     fail("'mut");
 }
 
+#[cfg(procmacro2_unstable)]
 #[test]
 fn span_test() {
     fn check_spans(p: &str, mut lines: &[(usize, usize, usize, usize)]) {
@@ -110,6 +111,7 @@ testing 123
 ]);
 }
 
+#[cfg(procmacro2_unstable)]
 #[cfg(not(feature = "unstable"))]
 #[test]
 fn default_span() {
@@ -120,10 +122,11 @@ fn default_span() {
     assert_eq!(end.line, 1);
     assert_eq!(end.column, 0);
     let source_file = Span::call_site().source_file();
-    assert_eq!(source_file.as_str(), "<unspecified>");
+    assert_eq!(source_file.path().to_string(), "<unspecified>");
     assert!(!source_file.is_real());
 }
 
+#[cfg(procmacro2_unstable)]
 #[test]
 fn span_join() {
     let source1 =

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -127,3 +127,27 @@ fn default_span() {
     assert!(!source_file.is_real());
 }
 
+#[test]
+fn span_join() {
+    let source1 =
+        "aaa\nbbb".parse::<TokenStream>().unwrap().into_iter().collect::<Vec<_>>();
+    let source2 =
+        "ccc\nddd".parse::<TokenStream>().unwrap().into_iter().collect::<Vec<_>>();
+
+    assert!(source1[0].span.source_file() != source2[0].span.source_file());
+    assert_eq!(source1[0].span.source_file(), source1[1].span.source_file());
+
+    let joined1 = source1[0].span.join(source1[1].span);
+    let joined2 = source1[0].span.join(source2[0].span);
+    assert!(joined1.is_some());
+    assert!(joined2.is_none());
+
+    let start = joined1.unwrap().start();
+    let end = joined1.unwrap().end();
+    assert_eq!(start.line, 1);
+    assert_eq!(start.column, 0);
+    assert_eq!(end.line, 2);
+    assert_eq!(end.column, 3);
+
+    assert_eq!(joined1.unwrap().source_file(), source1[0].span.source_file());
+}


### PR DESCRIPTION
This doesn't add support for the diagnostic methods on `Span` in stable rust. Perhaps we should add support for that, but I'm not sure what it would look like & I don't think we want a diagnostics engine in proc-macro2.

It does add support for things like fetching the line and column numbers of the start and end of a span.