### PR TITLE
Omit Span::lo/hi when not using procmacro2_unstable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 
 matrix:
   include:
-    - rust: 1.18.0
+    - rust: 1.15.0
     - rust: stable
     - rust: beta
     - rust: nightly

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,13 +170,13 @@ impl Span {
     #[cfg(procmacro2_unstable)]
     pub fn start(&self) -> LineColumn {
         let imp::LineColumn{ line, column } = self.0.start();
-        LineColumn { line, column }
+        LineColumn { line: line, column: column }
     }
 
     #[cfg(procmacro2_unstable)]
     pub fn end(&self) -> LineColumn {
         let imp::LineColumn{ line, column } = self.0.end();
-        LineColumn { line, column }
+        LineColumn { line: line, column: column }
     }
 
     #[cfg(procmacro2_unstable)]

--- a/src/stable.rs
+++ b/src/stable.rs
@@ -54,7 +54,6 @@ fn get_cursor(src: &str) -> Cursor {
 fn get_cursor(src: &str) -> Cursor {
     Cursor {
         rest: src,
-        off: 0,
     }
 }
 
@@ -313,15 +312,30 @@ impl Codemap {
 }
 
 #[derive(Clone, Copy, Debug)]
-pub struct Span { lo: u32, hi: u32 }
+pub struct Span {
+    #[cfg(procmacro2_unstable)]
+    lo: u32,
+    #[cfg(procmacro2_unstable)]
+    hi: u32,
+}
 
 impl Span {
     pub fn call_site() -> Span {
-        Span { lo: 0, hi: 0 }
+        Span {
+            #[cfg(procmacro2_unstable)]
+            lo: 0,
+            #[cfg(procmacro2_unstable)]
+            hi: 0,
+        }
     }
 
     pub fn def_site() -> Span {
-        Span { lo: 0, hi: 0 }
+        Span {
+            #[cfg(procmacro2_unstable)]
+            lo: 0,
+            #[cfg(procmacro2_unstable)]
+            hi: 0,
+        }
     }
 
     #[cfg(procmacro2_unstable)]
@@ -568,6 +582,16 @@ named!(token_stream -> ::TokenStream, map!(
     |trees| ::TokenStream(TokenStream { inner: trees })
 ));
 
+#[cfg(not(procmacro2_unstable))]
+fn token_tree(input: Cursor) -> PResult<TokenTree> {
+    let (input, kind) = token_kind(input)?;
+    Ok((input, TokenTree {
+        span: ::Span(Span {}),
+        kind: kind,
+    }))
+}
+
+#[cfg(procmacro2_unstable)]
 fn token_tree(input: Cursor) -> PResult<TokenTree> {
     let input = skip_whitespace(input);
     let lo = input.off;

--- a/src/stable.rs
+++ b/src/stable.rs
@@ -320,22 +320,18 @@ pub struct Span {
 }
 
 impl Span {
+    #[cfg(not(procmacro2_unstable))]
     pub fn call_site() -> Span {
-        Span {
-            #[cfg(procmacro2_unstable)]
-            lo: 0,
-            #[cfg(procmacro2_unstable)]
-            hi: 0,
-        }
+        Span {}
+    }
+
+    #[cfg(procmacro2_unstable)]
+    pub fn call_site() -> Span {
+        Span { lo: 0, hi: 0 }
     }
 
     pub fn def_site() -> Span {
-        Span {
-            #[cfg(procmacro2_unstable)]
-            lo: 0,
-            #[cfg(procmacro2_unstable)]
-            hi: 0,
-        }
+        Span::call_site()
     }
 
     #[cfg(procmacro2_unstable)]

--- a/src/strnom.rs
+++ b/src/strnom.rs
@@ -14,10 +14,16 @@ pub struct Cursor<'a> {
 }
 
 impl<'a> Cursor<'a> {
+    #[cfg(not(procmacro2_unstable))]
     pub fn advance(&self, amt: usize) -> Cursor<'a> {
         Cursor {
             rest: &self.rest[amt..],
-            #[cfg(procmacro2_unstable)]
+        }
+    }
+    #[cfg(procmacro2_unstable)]
+    pub fn advance(&self, amt: usize) -> Cursor<'a> {
+        Cursor {
+            rest: &self.rest[amt..],
             off: self.off + (amt as u32),
         }
     }

--- a/src/strnom.rs
+++ b/src/strnom.rs
@@ -9,6 +9,7 @@ use imp::LexError;
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Cursor<'a> {
     pub rest: &'a str,
+    #[cfg(procmacro2_unstable)]
     pub off: u32,
 }
 
@@ -16,6 +17,7 @@ impl<'a> Cursor<'a> {
     pub fn advance(&self, amt: usize) -> Cursor<'a> {
         Cursor {
             rest: &self.rest[amt..],
+            #[cfg(procmacro2_unstable)]
             off: self.off + (amt as u32),
         }
     }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,6 +1,13 @@
 extern crate proc_macro2;
 
-use proc_macro2::{Term, Literal, TokenStream, TokenNode, Span};
+use proc_macro2::{Term, Literal, TokenStream};
+
+#[cfg(procmacro2_unstable)]
+use proc_macro2::TokenNode;
+
+#[cfg(procmacro2_unstable)]
+#[cfg(not(feature = "unstable"))]
+use proc_macro2::Span;
 
 #[test]
 fn symbols() {


### PR DESCRIPTION
`Token![...]` being 24 bytes is a large number.