### PR TITLE
Span::unstable to expose the proc_macro::Span

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,6 +162,12 @@ impl Span {
         Span(imp::Span::def_site())
     }
 
+    /// This method is only available when the `"unstable"` feature is enabled.
+    #[cfg(feature = "unstable")]
+    pub fn unstable(self) -> proc_macro::Span {
+        self.0.unstable()
+    }
+
     #[cfg(procmacro2_unstable)]
     pub fn source_file(&self) -> SourceFile {
         SourceFile(self.0.source_file())

--- a/src/unstable.rs
+++ b/src/unstable.rs
@@ -225,6 +225,10 @@ impl Span {
         Span(proc_macro::Span::def_site())
     }
 
+    pub fn unstable(self) -> proc_macro::Span {
+        self.0
+    }
+
     #[cfg(procmacro2_unstable)]
     pub fn source_file(&self) -> SourceFile {
         SourceFile::new(self.0.source_file())


### PR DESCRIPTION
This is a way to expose the diagnostics API without a large surface area in proc_macro2. Sergio needed this for a [demo](https://github.com/SergioBenitez/syn/tree/next/examples/unstable).

```rust
let a = parser.parse::<ExprTuple>()?;
parser.parse::<token::Eq>()?;
let b = parser.parse::<ExprTuple>()?;
parser.eof()?;

let (a_len, b_len) = (a.elems.len(), b.elems.len());
if a_len != b_len {
    return Err(b.span().unstable()
        .error(format!("expected {} element(s), got {}", a_len, b_len))
        .span_note(a.span().unstable(), "because of this"));
}
```