### PR TITLE
Ensure that float literal is always formatted as floating point

### DIFF
--- a/src/stable.rs
+++ b/src/stable.rs
@@ -492,8 +492,15 @@ impl Literal {
         Literal(s.to_string())
     }
 
-    pub fn float(s: f64) -> Literal {
-        Literal(s.to_string())
+    pub fn float(n: f64) -> Literal {
+        if !n.is_finite() {
+            panic!("Invalid float literal {}", n);
+        }
+        let mut s = n.to_string();
+        if !s.contains('.') {
+            s += ".0";
+        }
+        Literal(s)
     }
 
     pub fn integer(s: i64) -> Literal {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -19,6 +19,7 @@ fn symbols() {
 fn literals() {
     assert_eq!(Literal::string("foo").to_string(), "\"foo\"");
     assert_eq!(Literal::string("\"").to_string(), "\"\\\"\"");
+    assert_eq!(Literal::float(10.0).to_string(), "10.0");
 }
 
 #[test]


### PR DESCRIPTION
Previously `Literal::float` could print as something that parsed as an integer.