### PR TITLE
Span::resolved_at and Span::located_at to combine behavior of two spans

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,6 +162,18 @@ impl Span {
         Span(imp::Span::def_site())
     }
 
+    /// Creates a new span with the same line/column information as `self` but
+    /// that resolves symbols as though it were at `other`.
+    pub fn resolved_at(&self, other: Span) -> Span {
+        Span(self.0.resolved_at(other.0))
+    }
+
+    /// Creates a new span with the same name resolution behavior as `self` but
+    /// with the line/column information of `other`.
+    pub fn located_at(&self, other: Span) -> Span {
+        Span(self.0.located_at(other.0))
+    }
+
     /// This method is only available when the `"nightly"` feature is enabled.
     #[cfg(feature = "nightly")]
     pub fn unstable(self) -> proc_macro::Span {

--- a/src/stable.rs
+++ b/src/stable.rs
@@ -334,6 +334,17 @@ impl Span {
         Span::call_site()
     }
 
+    pub fn resolved_at(&self, _other: Span) -> Span {
+        // Stable spans consist only of line/column information, so
+        // `resolved_at` and `located_at` only select which span the
+        // caller wants line/column information from.
+        *self
+    }
+
+    pub fn located_at(&self, other: Span) -> Span {
+        other
+    }
+
     #[cfg(procmacro2_semver_exempt)]
     pub fn source_file(&self) -> SourceFile {
         CODEMAP.with(|cm| {

--- a/src/unstable.rs
+++ b/src/unstable.rs
@@ -225,6 +225,14 @@ impl Span {
         Span(proc_macro::Span::def_site())
     }
 
+    pub fn resolved_at(&self, other: Span) -> Span {
+        Span(self.0.resolved_at(other.0))
+    }
+
+    pub fn located_at(&self, other: Span) -> Span {
+        Span(self.0.located_at(other.0))
+    }
+
     pub fn unstable(self) -> proc_macro::Span {
         self.0
     }


### PR DESCRIPTION
Added upstream in https://github.com/rust-lang/rust/pull/47149.

Proc macro spans serve two mostly unrelated purposes: controlling name resolution and controlling error messages. It can be useful to mix the name resolution behavior of one span with the line/column error message locations of a different span.

In particular, consider the case of a trait brought into scope within the def_site of a custom derive. I want to invoke trait methods on the fields of the user's struct. If the field type does not implement the right trait, I want the error message to underline the corresponding struct field.

Generating the method call with the def_site span is not ideal -- it compiles and runs but error messages sadly always point to the derive attribute like we saw with Macros 1.1.

```
  |
4 | #[derive(HeapSize)]
  |          ^^^^^^^^
```

Generating the method call with the same span as the struct field's ident or type is not correct -- it shows the right underlines but fails to resolve to the trait in scope at the def_site.

```
  |
7 |     bad: std::thread::Thread,
  |     ^^^^^^^^^^^^^^^^^^^^^^^^
```

The correct span for the method call is one that combines the def_site's name resolution with the struct field's line/column.

```rust
field.span.resolved_at(Span::def_site())

// equivalently
Span::def_site().located_at(field.span)
```

Adding both because which one is more natural will depend on context.