### PR TITLE
Use the same api for imp::Term as for Term

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,11 +242,11 @@ pub struct Term(imp::Term);
 
 impl Term {
     pub fn intern(string: &str) -> Term {
-        Term(string.into())
+        Term(imp::Term::intern(string))
     }
 
     pub fn as_str(&self) -> &str {
-        &self.0
+        self.0.as_str()
     }
 }
 

--- a/src/stable.rs
+++ b/src/stable.rs
@@ -7,7 +7,6 @@ use std::collections::HashMap;
 use std::fmt;
 use std::iter;
 use std::marker::PhantomData;
-use std::ops;
 use std::rc::Rc;
 use std::str::FromStr;
 use std::vec;
@@ -398,19 +397,15 @@ pub struct Term {
 
 thread_local!(static SYMBOLS: RefCell<Interner> = RefCell::new(Interner::new()));
 
-impl<'a> From<&'a str> for Term {
-    fn from(string: &'a str) -> Term {
+impl Term {
+    pub fn intern(string: &str) -> Term {
         Term {
             intern: SYMBOLS.with(|s| s.borrow_mut().intern(string)),
             not_send_sync: PhantomData,
         }
     }
-}
 
-impl ops::Deref for Term {
-    type Target = str;
-
-    fn deref(&self) -> &str {
+    pub fn as_str(&self) -> &str {
         SYMBOLS.with(|interner| {
             let interner = interner.borrow();
             let s = interner.get(self.intern);
@@ -423,7 +418,7 @@ impl ops::Deref for Term {
 
 impl fmt::Debug for Term {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_tuple("Term").field(&&**self).finish()
+        f.debug_tuple("Term").field(&self.as_str()).finish()
     }
 }
 

--- a/src/unstable.rs
+++ b/src/unstable.rs
@@ -1,7 +1,6 @@
 use std::ascii;
 use std::fmt;
 use std::iter;
-use std::ops;
 use std::str::FromStr;
 
 use proc_macro;
@@ -269,16 +268,12 @@ impl fmt::Debug for Span {
 #[derive(Copy, Clone)]
 pub struct Term(proc_macro::Term);
 
-impl<'a> From<&'a str> for Term {
-    fn from(string: &'a str) -> Term {
+impl Term {
+    pub fn intern(string: &str) -> Term {
         Term(proc_macro::Term::intern(string))
     }
-}
 
-impl ops::Deref for Term {
-    type Target = str;
-
-    fn deref(&self) -> &str {
+    pub fn as_str(&self) -> &str {
         self.0.as_str()
     }
 }


### PR DESCRIPTION
Cleanup only, does not affect the public api.