### PR TITLE
Add a special case for empty `/*` comments

### DIFF
--- a/src/strnom.rs
+++ b/src/strnom.rs
@@ -80,6 +80,9 @@ pub fn whitespace(input: Cursor) -> PResult<()> {
                     continue;
                 }
                 break;
+            } else if s.starts_with("/**/") {
+                i += 4;
+                continue
             } else if s.starts_with("/*") && (!s.starts_with("/**") || s.starts_with("/***")) &&
                       !s.starts_with("/*!") {
                 let (_, com) = block_comment(s)?;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -170,3 +170,10 @@ fn no_panic() {
     assert!(s.parse::<proc_macro2::TokenStream>().is_err());
 }
 
+#[test]
+fn tricky_doc_commaent() {
+    let stream = "/**/".parse::<proc_macro2::TokenStream>().unwrap();
+    let tokens = stream.into_iter().collect::<Vec<_>>();
+    assert!(tokens.is_empty(), "not empty -- {:?}", tokens);
+}
+


### PR DESCRIPTION
Looks like they didn't fall into quite the right position!

Closes #57