### PR TITLE
Add a feature for linking to `proc-macro`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
       script:
         - cargo test
         - cargo build --features nightly
+        - cargo build --no-default-features
         - RUSTFLAGS='--cfg procmacro2_semver_exempt' cargo test
         - RUSTFLAGS='--cfg procmacro2_semver_exempt' cargo build --features nightly
         - RUSTFLAGS='--cfg procmacro2_semver_exempt' cargo doc --no-deps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ unicode-xid = "0.1"
 #
 # When disabled: emulate the same API as the nightly compiler's proc_macro crate
 # but in a way that works on all stable compilers >=1.15.0.
-nightly = []
+nightly = ["proc-macro"]
 
 proc-macro = []
 default = ["proc-macro"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,6 @@ unicode-xid = "0.1"
 # When disabled: emulate the same API as the nightly compiler's proc_macro crate
 # but in a way that works on all stable compilers >=1.15.0.
 nightly = []
+
+proc-macro = []
+default = ["proc-macro"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@
 
 #![cfg_attr(feature = "nightly", feature(proc_macro))]
 
+#[cfg(feature = "proc-macro")]
 extern crate proc_macro;
 
 #[cfg(not(feature = "nightly"))]
@@ -67,12 +68,14 @@ impl FromStr for TokenStream {
     }
 }
 
+#[cfg(feature = "proc-macro")]
 impl From<proc_macro::TokenStream> for TokenStream {
     fn from(inner: proc_macro::TokenStream) -> TokenStream {
         TokenStream(inner.into())
     }
 }
 
+#[cfg(feature = "proc-macro")]
 impl From<TokenStream> for proc_macro::TokenStream {
     fn from(inner: TokenStream) -> proc_macro::TokenStream {
         inner.0.into()
@@ -175,7 +178,7 @@ impl Span {
     }
 
     /// This method is only available when the `"nightly"` feature is enabled.
-    #[cfg(feature = "nightly")]
+    #[cfg(all(feature = "nightly", feature = "proc-macro"))]
     pub fn unstable(self) -> proc_macro::Span {
         self.0.unstable()
     }

--- a/src/stable.rs
+++ b/src/stable.rs
@@ -11,7 +11,6 @@ use std::rc::Rc;
 use std::str::FromStr;
 use std::vec;
 
-use proc_macro;
 use unicode_xid::UnicodeXID;
 use strnom::{Cursor, PResult, skip_whitespace, block_comment, whitespace, word_break};
 
@@ -120,14 +119,16 @@ impl fmt::Display for TokenStream {
     }
 }
 
-impl From<proc_macro::TokenStream> for TokenStream {
-    fn from(inner: proc_macro::TokenStream) -> TokenStream {
+#[cfg(feature = "proc-macro")]
+impl From<::proc_macro::TokenStream> for TokenStream {
+    fn from(inner: ::proc_macro::TokenStream) -> TokenStream {
         inner.to_string().parse().expect("compiler token stream parse failed")
     }
 }
 
-impl From<TokenStream> for proc_macro::TokenStream {
-    fn from(inner: TokenStream) -> proc_macro::TokenStream {
+#[cfg(feature = "proc-macro")]
+impl From<TokenStream> for ::proc_macro::TokenStream {
+    fn from(inner: TokenStream) -> ::proc_macro::TokenStream {
         inner.to_string().parse().expect("failed to parse to compiler tokens")
     }
 }


### PR DESCRIPTION
This commit adds a feature to this crate which enables linking to the
upstream `proc_macro` crate. This should help this compile on targets
which don't have `proc_macro` and allow it to also be suitable for
embedding in Rust binaries.

This feature is turned on by default for backwards compatibility right
now.