### PR TITLE
Add PartialEq and Eq implementations for Span

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,7 +153,7 @@ pub struct LineColumn {
     pub column: usize,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub struct Span(imp::Span);
 
 impl Span {

--- a/src/stable.rs
+++ b/src/stable.rs
@@ -311,7 +311,7 @@ impl Codemap {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Span {
     #[cfg(procmacro2_semver_exempt)]
     lo: u32,

--- a/src/unstable.rs
+++ b/src/unstable.rs
@@ -212,7 +212,7 @@ pub struct LineColumn {
     pub column: usize,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub struct Span(proc_macro::Span);
 
 impl From<proc_macro::Span> for ::Span {


### PR DESCRIPTION
This would fix #68 

There's also the option to put this behind the `procmacro2_semver_exempt` flag if we don't feel confident enough in the stability of this trait impl.

The biggest advantage here of an API like this is it would allow you to write something like:
```rust
// Say you have two `syn::Ident`s, a and b, and you want to see if they 
// would refer to the same object (considering hygiene):
fn same_ident(a: Ident, b: Ident) -> bool {
    a.as_ref() == b.as_ref() && a.span.resolved_at(b.span) == a.span
}
```