### PR TITLE
Improve Debug representations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,7 +251,7 @@ impl fmt::Debug for Span {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub enum TokenTree {
     Group(Group),
     Term(Term),
@@ -314,7 +314,20 @@ impl fmt::Display for TokenTree {
     }
 }
 
-#[derive(Clone, Debug)]
+impl fmt::Debug for TokenTree {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // Each of these has the name in the struct type in the derived debug,
+        // so don't bother with an extra layer of indirection
+        match *self {
+            TokenTree::Group(ref t) => t.fmt(f),
+            TokenTree::Term(ref t) => t.fmt(f),
+            TokenTree::Op(ref t) => t.fmt(f),
+            TokenTree::Literal(ref t) => t.fmt(f),
+        }
+    }
+}
+
+#[derive(Clone)]
 pub struct Group {
     delimiter: Delimiter,
     stream: TokenStream,
@@ -361,7 +374,18 @@ impl fmt::Display for Group {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+impl fmt::Debug for Group {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        let mut debug = fmt.debug_struct("Group");
+        debug.field("delimiter", &self.delimiter);
+        debug.field("stream", &self.stream);
+        #[cfg(procmacro2_semver_exempt)]
+        debug.field("span", &self.span);
+        debug.finish()
+    }
+}
+
+#[derive(Copy, Clone)]
 pub struct Op {
     op: char,
     spacing: Spacing,
@@ -403,6 +427,17 @@ impl Op {
 impl fmt::Display for Op {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.op.fmt(f)
+    }
+}
+
+impl fmt::Debug for Op {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        let mut debug = fmt.debug_struct("Op");
+        debug.field("op", &self.op);
+        debug.field("spacing", &self.spacing);
+        #[cfg(procmacro2_semver_exempt)]
+        debug.field("span", &self.span);
+        debug.finish()
     }
 }
 

--- a/src/stable.rs
+++ b/src/stable.rs
@@ -16,7 +16,7 @@ use unicode_xid::UnicodeXID;
 
 use {Delimiter, Group, Op, Spacing, TokenTree};
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct TokenStream {
     inner: Vec<TokenTree>,
 }
@@ -108,6 +108,13 @@ impl fmt::Display for TokenStream {
         }
 
         Ok(())
+    }
+}
+
+impl fmt::Debug for TokenStream {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("TokenStream ")?;
+        f.debug_list().entries(self.clone()).finish()
     }
 }
 
@@ -314,7 +321,7 @@ impl Codemap {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct Span {
     #[cfg(procmacro2_semver_exempt)]
     lo: u32,
@@ -393,6 +400,16 @@ impl Span {
     }
 }
 
+impl fmt::Debug for Span {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        #[cfg(procmacro2_semver_exempt)]
+        return write!(f, "bytes({}..{})", self.lo, self.hi);
+
+        #[cfg(not(procmacro2_semver_exempt))]
+        write!(f, "Span")
+    }
+}
+
 #[derive(Copy, Clone)]
 pub struct Term {
     intern: usize,
@@ -466,7 +483,11 @@ fn validate_term(string: &str) {
 
 impl fmt::Debug for Term {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_tuple("Term").field(&self.as_str()).finish()
+        let mut debug = f.debug_struct("Term");
+        debug.field("sym", &format_args!("{}", self.as_str()));
+        #[cfg(procmacro2_semver_exempt)]
+        debug.field("span", &self.span);
+        debug.finish()
     }
 }
 
@@ -508,7 +529,7 @@ impl Interner {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct Literal {
     text: String,
     span: Span,
@@ -626,6 +647,16 @@ impl Literal {
 impl fmt::Display for Literal {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.text.fmt(f)
+    }
+}
+
+impl fmt::Debug for Literal {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        let mut debug = fmt.debug_struct("Literal");
+        debug.field("lit", &format_args!("{}", self.text));
+        #[cfg(procmacro2_semver_exempt)]
+        debug.field("span", &self.span);
+        debug.finish()
     }
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -302,3 +302,56 @@ fn raw_identifier() {
     }
     assert!(tts.next().is_none());
 }
+
+#[test]
+fn test_debug() {
+    let tts = TokenStream::from_str("[a + 1]").unwrap();
+
+    #[cfg(not(procmacro2_semver_exempt))]
+    let expected = "\
+TokenStream [
+    Group {
+        delimiter: Bracket,
+        stream: TokenStream [
+            Term {
+                sym: a
+            },
+            Op {
+                op: '+',
+                spacing: Alone
+            },
+            Literal {
+                lit: 1
+            }
+        ]
+    }
+]\
+    ";
+
+    #[cfg(procmacro2_semver_exempt)]
+    let expected = "\
+TokenStream [
+    Group {
+        delimiter: Bracket,
+        stream: TokenStream [
+            Term {
+                sym: a,
+                span: bytes(2..3)
+            },
+            Op {
+                op: '+',
+                spacing: Alone,
+                span: bytes(4..5)
+            },
+            Literal {
+                lit: 1,
+                span: bytes(6..7)
+            }
+        ],
+        span: bytes(1..8)
+    }
+]\
+    ";
+
+    assert_eq!(expected, format!("{:#?}", tts));
+}


### PR DESCRIPTION
This is ported from https://github.com/rust-lang/rust/pull/49748. I decided not to print a `span:` field when we are not emulating spans because they are just noise.

```rust
TokenStream [
    Group {
        delimiter: Bracket,
        stream: TokenStream [
            Term {
                sym: a
            },
            Op {
                op: '+',
                spacing: Alone
            },
            Literal {
                lit: 1
            }
        ]
    }
]
```