### PR TITLE
Track upstream proc_macro changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proc-macro2"
-version = "0.3.8" # remember to update html_root_url
+version = "0.4.0" # remember to update html_root_url
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ itself. Usage is done via:
 
 ```toml
 [dependencies]
-proc-macro2 = "0.3"
+proc-macro2 = "0.4"
 ```
 
 followed by
@@ -57,7 +57,7 @@ You can enable this feature via:
 
 ```toml
 [dependencies]
-proc-macro2 = { version = "0.3", features = ["nightly"] }
+proc-macro2 = { version = "0.4", features = ["nightly"] }
 ```
 
 


### PR DESCRIPTION
* Rename `Term` to `Ident`
* Rename `Punct` to `Op`
* Remove `Term::as_str`
* Rename `Op::op` to `Punct::as_char`
* `Term::new` no longer accepts lifetimes or raw idents
* Lifetimes are lexed as a `Joint` `'` character followed by an `Ident`
* `Ident::new_raw` is a new `procmacro2_semver_exempt` API for creating raw
  identifiers.
* `{Eq,PartialEq,Ord,PartialOrd,Hash} for Ident`
* Remove `Copy for Term`
* Remove `Copy for Op`
* Add `Extend<TokenTree> for TokenStream`