### PR TITLE
Parse `_` as an ident

### DIFF
--- a/src/stable.rs
+++ b/src/stable.rs
@@ -787,8 +787,6 @@ fn symbol(input: Cursor) -> PResult<TokenTree> {
     let a = &input.rest[..end];
     if a == "r#_" {
         Err(LexError)
-    } else if a == "_" {
-        Ok((input.advance(end), Punct::new('_', Spacing::Alone).into()))
     } else {
         let ident = if raw {
             ::Ident::_new_raw(&a[2..], ::Span::call_site())

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -113,6 +113,7 @@ fn roundtrip() {
     ",
     );
     roundtrip("'a");
+    roundtrip("'_");
     roundtrip("'static");
     roundtrip("'\\u{10__FFFF}'");
     roundtrip("\"\\u{10_F0FF__}foo\\u{1_0_0_0__}\"");


### PR DESCRIPTION
Technically a breaking change but 0.4 is so new I'm tempted to leave this as
0.4.1

Closes #87