### PR TITLE
Ident == AsRef<str>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -521,6 +521,15 @@ impl PartialEq for Ident {
     }
 }
 
+impl<T> PartialEq<T> for Ident
+where
+    T: ?Sized + AsRef<str>,
+{
+    fn eq(&self, other: &T) -> bool {
+        self.to_string() == other.as_ref()
+    }
+}
+
 impl Eq for Ident {}
 
 impl PartialOrd for Ident {


### PR DESCRIPTION
This is the signature of the [PartialEq impl from Syn 0.13](https://docs.rs/syn/0.13/syn/struct.Ident.html#implementations) which has worked great. It avoids `ident.to_string() == "..."` which triggers a negative reaction in many users in my experience.