### PR TITLE
Add `TokenStream::iter`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1031,4 +1031,36 @@ pub mod token_stream {
             }
         }
     }
+
+    /// A borrowed iterator over `TokenStream`'s `TokenTree`s.
+    ///
+    /// The iteration is "shallow", e.g. the iterator doesn't recurse into
+    /// delimited groups, and returns whole groups as token trees.
+    pub struct Iter<'a> {
+        inner: imp::TokenTreeBorrowedIter<'a>,
+        _marker: marker::PhantomData<Rc<()>>,
+    }
+
+    impl <'a> Iterator for Iter<'a> {
+        type Item = &'a TokenTree;
+
+        fn next(&mut self) -> Option<&'a TokenTree> {
+            self.inner.next()
+        }
+    }
+
+    impl <'a> fmt::Debug for Iter<'a> {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            self.inner.fmt(f)
+        }
+    }
+
+    impl TokenStream {
+        pub fn iter(&self) -> Iter {
+            Iter {
+                inner: self.inner.iter(),
+                _marker: marker::PhantomData,
+            }
+        }
+    }
 }

--- a/src/stable.rs
+++ b/src/stable.rs
@@ -8,6 +8,7 @@ use std::fmt;
 use std::iter;
 use std::str::FromStr;
 use std::vec;
+use std::slice;
 
 use strnom::{block_comment, skip_whitespace, whitespace, word_break, Cursor, PResult};
 use unicode_xid::UnicodeXID;
@@ -29,6 +30,10 @@ impl TokenStream {
 
     pub fn is_empty(&self) -> bool {
         self.inner.len() == 0
+    }
+
+    pub fn iter(&self) -> TokenTreeBorrowedIter {
+        self.inner.iter()
     }
 }
 
@@ -161,6 +166,7 @@ impl Extend<TokenTree> for TokenStream {
 }
 
 pub type TokenTreeIter = vec::IntoIter<TokenTree>;
+pub type TokenTreeBorrowedIter<'a> = slice::Iter<'a, TokenTree>;
 
 impl IntoIterator for TokenStream {
     type Item = TokenTree;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -381,3 +381,14 @@ TokenStream [
 
     assert_eq!(expected, format!("{:#?}", tts));
 }
+
+#[test]
+fn test_tokenstream_iter() {
+    let tokenstream_res = "f(x)".parse::<TokenStream>();
+    assert!(tokenstream_res.is_ok());
+
+    let tokenstream = tokenstream_res.unwrap();
+    let mut iter = tokenstream.iter();
+    assert_eq!("Ident { sym: f }", format!("{:?}", iter.next().unwrap()));
+    assert_eq!("Group { delimiter: Parenthesis, stream: TokenStream [Ident { sym: x }] }", format!("{:?}", iter.next().unwrap()));
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -389,6 +389,21 @@ fn test_tokenstream_iter() {
 
     let tokenstream = tokenstream_res.unwrap();
     let mut iter = tokenstream.iter();
-    assert_eq!("Ident { sym: f }", format!("{:?}", iter.next().unwrap()));
-    assert_eq!("Group { delimiter: Parenthesis, stream: TokenStream [Ident { sym: x }] }", format!("{:?}", iter.next().unwrap()));
+    #[cfg(not(procmacro2_semver_exempt))]
+    {
+        assert_eq!("Ident { sym: f }", format!("{:?}", iter.next().unwrap()));
+        assert_eq!(
+            "Group { delimiter: Parenthesis, stream: TokenStream [Ident { sym: x }] }",
+            format!("{:?}", iter.next().unwrap())
+        );
+    }
+    #[cfg(procmacro2_semver_exempt)]
+    {
+        assert_eq!("Ident { sym: f, span: bytes(1..2) }", format!("{:?}", iter.next().unwrap()));
+        assert_eq!(
+            "Group { delimiter: Parenthesis, stream: TokenStream [Ident { sym: x, span: bytes(3..4) }], \
+            span: bytes(2..5) }",
+            format!("{:?}", iter.next().unwrap())
+        );
+    }
 }


### PR DESCRIPTION
As `TokenStream` implements `IntoIterator` I see no reason not to have a borrowed iterator method.