### PR TITLE
Ignore proc-macro feature on wasm-target

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@
 #![doc(html_root_url = "https://docs.rs/proc-macro2/0.4.9")]
 #![cfg_attr(feature = "nightly", feature(proc_macro_raw_ident, proc_macro_span))]
 
-#[cfg(feature = "proc-macro")]
+#[cfg(all(not(all(target_arch = "wasm32", target_os = "unknown")), feature = "proc-macro"))]
 extern crate proc_macro;
 extern crate unicode_xid;
 
@@ -146,14 +146,14 @@ impl FromStr for TokenStream {
     }
 }
 
-#[cfg(feature = "proc-macro")]
+#[cfg(all(not(all(target_arch = "wasm32", target_os = "unknown")), feature = "proc-macro"))]
 impl From<proc_macro::TokenStream> for TokenStream {
     fn from(inner: proc_macro::TokenStream) -> TokenStream {
         TokenStream::_new(inner.into())
     }
 }
 
-#[cfg(feature = "proc-macro")]
+#[cfg(all(not(all(target_arch = "wasm32", target_os = "unknown")), feature = "proc-macro"))]
 impl From<TokenStream> for proc_macro::TokenStream {
     fn from(inner: TokenStream) -> proc_macro::TokenStream {
         inner.inner.into()
@@ -318,7 +318,7 @@ impl Span {
     }
 
     /// This method is only available when the `"nightly"` feature is enabled.
-    #[cfg(all(feature = "nightly", feature = "proc-macro"))]
+    #[cfg(all(not(all(target_arch = "wasm32", target_os = "unknown")), feature = "nightly", feature = "proc-macro"))]
     pub fn unstable(self) -> proc_macro::Span {
         self.inner.unstable()
     }

--- a/src/stable.rs
+++ b/src/stable.rs
@@ -116,7 +116,7 @@ impl fmt::Debug for TokenStream {
     }
 }
 
-#[cfg(feature = "proc-macro")]
+#[cfg(all(not(all(target_arch = "wasm32", target_os = "unknown")), feature = "proc-macro"))]
 impl From<::proc_macro::TokenStream> for TokenStream {
     fn from(inner: ::proc_macro::TokenStream) -> TokenStream {
         inner
@@ -126,7 +126,7 @@ impl From<::proc_macro::TokenStream> for TokenStream {
     }
 }
 
-#[cfg(feature = "proc-macro")]
+#[cfg(all(not(all(target_arch = "wasm32", target_os = "unknown")), feature = "proc-macro"))]
 impl From<TokenStream> for ::proc_macro::TokenStream {
     fn from(inner: TokenStream) -> ::proc_macro::TokenStream {
         inner


### PR DESCRIPTION
This causes the `proc-macro` feature to be ignored for wasm-targets where proc-macro is not available. Currently, if a crate is to be built that depends on `proc-macro2`, the `proc-macro` feature from an actual proc-macro leaks into the build-environment of `proc-macro2` even if `default-features = []`, causing the build to fail.

This patch enables me to build (and run) my crate on wasm-targets.

I don't know if the patch is actually fully correct or not. If it is, it would be nice to be pushed into a 0.4.10-release. `stdweb` has [recently](https://github.com/koute/stdweb/issues/257) bumped its dependencies in order to wait for this patch in `0.4`. There are also patches like this waiting for `quote` and `syn`.