### PR TITLE
Restore compatibility with rustc 1.15-1.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ keywords = ["macros"]
 repository = "https://github.com/alexcrichton/proc-macro2"
 homepage = "https://github.com/alexcrichton/proc-macro2"
 documentation = "https://docs.rs/proc-macro2"
+build = "build.rs"
 description = """
 A stable implementation of the upcoming new `proc_macro` API. Comes with an
 option, off by default, to also reimplement itself in terms of the upstream


### PR DESCRIPTION
The build script from https://github.com/alexcrichton/proc-macro2/commit/5354848b97357fce067d2edad5de614e084c8888 is not picked up automatically pre-1.17 so those compilers were not building with `use_proc_macro` even though that should have been the default.