### PR TITLE
Revert "Disable linking to `proc_macro` on musl"

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -14,12 +14,6 @@ fn maybe_enable_use_proc_macro(target: &str) {
         return;
     }
 
-    // There are currently no musl builds of the compiler, so proc_macro is
-    // always missing, so disable this feature.
-    if target.contains("-musl") {
-        return;
-    }
-
     // Otherwise, only enable it if our feature is actually enabled.
     if cfg!(feature = "proc-macro") {
         println!("cargo:rustc-cfg=use_proc_macro");


### PR DESCRIPTION
This reverts commit f3d1b2c7818be3fc8f856433092b91c6a8b8cbeb. Fixes https://github.com/dtolnay/syn/issues/470.