### PR TITLE
Optimize PartialEq impls for Ident

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -822,7 +822,7 @@ impl Ident {
 
 impl PartialEq for Ident {
     fn eq(&self, other: &Ident) -> bool {
-        self.to_string() == other.to_string()
+        self.inner == other.inner
     }
 }
 
@@ -831,7 +831,7 @@ where
     T: ?Sized + AsRef<str>,
 {
     fn eq(&self, other: &T) -> bool {
-        self.to_string() == other.as_ref()
+        self.inner == other
     }
 }
 

--- a/src/stable.rs
+++ b/src/stable.rs
@@ -500,6 +500,26 @@ fn validate_term(string: &str) {
     }
 }
 
+impl PartialEq for Ident {
+    fn eq(&self, other: &Ident) -> bool {
+        self.sym == other.sym && self.raw == other.raw
+    }
+}
+
+impl<T> PartialEq<T> for Ident
+where
+    T: ?Sized + AsRef<str>,
+{
+    fn eq(&self, other: &T) -> bool {
+        let other = other.as_ref();
+        if self.raw {
+            other.starts_with("r#") && self.sym == other[2..]
+        } else {
+            self.sym == other
+        }
+    }
+}
+
 impl fmt::Display for Ident {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.raw {

--- a/src/unstable.rs
+++ b/src/unstable.rs
@@ -573,6 +573,29 @@ impl Ident {
     }
 }
 
+impl PartialEq for Ident {
+    fn eq(&self, other: &Ident) -> bool {
+        match (self, other) {
+            (Ident::Nightly(t), Ident::Nightly(o)) => t.to_string() == o.to_string(),
+            (Ident::Stable(t), Ident::Stable(o)) => t == o,
+            _ => mismatch(),
+        }
+    }
+}
+
+impl<T> PartialEq<T> for Ident
+where
+    T: ?Sized + AsRef<str>,
+{
+    fn eq(&self, other: &T) -> bool {
+        let other = other.as_ref();
+        match self {
+            Ident::Nightly(t) => t.to_string() == other,
+            Ident::Stable(t) => t == other,
+        }
+    }
+}
+
 impl fmt::Display for Ident {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {


### PR DESCRIPTION
The second of these impls is very hot in Syn. This commit improves performance by 15% when executing in stable mode, dropping the time to parse all of rust-lang/rust + submodules from 7.8 seconds to 6.6 seconds.