### PR TITLE
Remove semver exempt testing from 1.15 and stable builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ matrix:
     - rust: 1.15.0
     - rust: stable
     - rust: beta
-      script: cargo test
     - rust: nightly
       install: rustup target add wasm32-unknown-unknown
       script: cargo test --target wasm32-unknown-unknown --no-run
@@ -24,7 +23,6 @@ before_script:
 
 script:
   - cargo test
-  - RUSTFLAGS='--cfg procmacro2_semver_exempt' cargo test
 
 notifications:
   email:


### PR DESCRIPTION
The `procmacro2_semver_exempt` feature tracks whatever is in nightly, so we reserve the right to remain broken on compilers that are not nightly.

Per https://github.com/alexcrichton/proc-macro2/pull/128#issuecomment-419167363.