### PR TITLE
Adds def site feature to super-unstable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@
 #![doc(html_root_url = "https://docs.rs/proc-macro2/0.4.19")]
 #![cfg_attr(
     super_unstable,
-    feature(proc_macro_raw_ident, proc_macro_span)
+    feature(proc_macro_raw_ident, proc_macro_span, proc_macro_def_site)
 )]
 
 #[cfg(use_proc_macro)]


### PR DESCRIPTION
As per my extra comment to #132 this adds the def_site feature to proc-macro2 so it'll compile with the latest nightly.