### PR TITLE
Add support for 128-bit integers

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -7,15 +7,19 @@ fn main() {
 
     let target = env::var("TARGET").unwrap();
 
-    if !enable_use_proc_macro(&target) {
-        return;
-    }
-    println!("cargo:rustc-cfg=use_proc_macro");
-
     let minor = match rustc_minor_version() {
         Some(n) => n,
         None => return,
     };
+
+    if minor >= 26 {
+        println!("cargo:rustc-cfg=u128");
+    }
+
+    if !enable_use_proc_macro(&target) {
+        return;
+    }
+    println!("cargo:rustc-cfg=use_proc_macro");
 
     // Rust 1.29 stabilized the necessary APIs in the `proc_macro` crate
     if minor >= 29 || cfg!(feature = "nightly") {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -973,6 +973,12 @@ impl Literal {
         isize_suffixed => isize,
     }
 
+    #[cfg(u128)]
+    suffixed_int_literals! {
+        u128_suffixed => u128,
+        i128_suffixed => i128,
+    }
+
     unsuffixed_int_literals! {
         u8_unsuffixed => u8,
         u16_unsuffixed => u16,
@@ -984,6 +990,12 @@ impl Literal {
         i32_unsuffixed => i32,
         i64_unsuffixed => i64,
         isize_unsuffixed => isize,
+    }
+
+    #[cfg(u128)]
+    unsuffixed_int_literals! {
+        u128_unsuffixed => u128,
+        i128_unsuffixed => i128,
     }
 
     pub fn f64_unsuffixed(f: f64) -> Literal {

--- a/src/stable.rs
+++ b/src/stable.rs
@@ -678,6 +678,12 @@ impl Literal {
         f64_suffixed => f64,
     }
 
+    #[cfg(u128)]
+    suffixed_numbers! {
+        u128_suffixed => u128,
+        i128_suffixed => i128,
+    }
+
     unsuffixed_numbers! {
         u8_unsuffixed => u8,
         u16_unsuffixed => u16,
@@ -689,6 +695,12 @@ impl Literal {
         i32_unsuffixed => i32,
         i64_unsuffixed => i64,
         isize_unsuffixed => isize,
+    }
+
+    #[cfg(u128)]
+    unsuffixed_numbers! {
+        u128_unsuffixed => u128,
+        i128_unsuffixed => i128,
     }
 
     pub fn f32_unsuffixed(f: f32) -> Literal {

--- a/src/unstable.rs
+++ b/src/unstable.rs
@@ -819,6 +819,12 @@ impl Literal {
         f64_suffixed => f64,
     }
 
+    #[cfg(u128)]
+    suffixed_numbers! {
+        i128_suffixed => i128,
+        u128_suffixed => u128,
+    }
+
     unsuffixed_integers! {
         u8_unsuffixed => u8,
         u16_unsuffixed => u16,
@@ -830,6 +836,12 @@ impl Literal {
         i32_unsuffixed => i32,
         i64_unsuffixed => i64,
         isize_unsuffixed => isize,
+    }
+
+    #[cfg(u128)]
+    unsuffixed_integers! {
+        i128_unsuffixed => i128,
+        u128_unsuffixed => u128,
     }
 
     pub fn f32_unsuffixed(f: f32) -> Literal {


### PR DESCRIPTION
Only compile in this support if rustc is new enough, otherwise continue
to omit the bindings for older-than-1.26 rustc

Closes #143