### PR TITLE
Allow to use procmacro2_semver_exempt on stable rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_script:
 
 script:
   - cargo test
+  - RUSTFLAGS='--cfg procmacro2_semver_exempt' cargo test
 
 notifications:
   email:

--- a/build.rs
+++ b/build.rs
@@ -22,7 +22,7 @@ fn main() {
     println!("cargo:rustc-cfg=use_proc_macro");
 
     // Rust 1.29 stabilized the necessary APIs in the `proc_macro` crate
-    if minor >= 29 || cfg!(feature = "nightly") {
+    if (minor >= 29 && !cfg!(procmacro2_semver_exempt)) || cfg!(feature = "nightly") {
         println!("cargo:rustc-cfg=wrap_proc_macro");
 
         if cfg!(procmacro2_semver_exempt) {


### PR DESCRIPTION
procmacro2_semver_exempt is working on rust < 1.29, but
since 1.29, proc_macro2 forward to proc_macro even when
procmacro2_semver_exempt is set, which require a nightly
compiler