### PR TITLE
Update documentation to 2018 edition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,19 +3,8 @@ sudo: false
 
 matrix:
   include:
-    - rust: 1.15.0 # oldest supported version
-      script:
-        - cargo build
-        - cargo build --no-default-features
-        - RUSTFLAGS='--cfg procmacro2_semver_exempt' cargo build
-        - RUSTFLAGS='--cfg procmacro2_semver_exempt' cargo build --no-default-features
-    - rust: 1.19.0 # first release with the --tests flag
-      script:
-        - cargo test --tests
-        - cargo test --no-default-features --tests
-        - RUSTFLAGS='--cfg procmacro2_semver_exempt' cargo test --tests
-        - RUSTFLAGS='--cfg procmacro2_semver_exempt' cargo test --no-default-features --tests
-    - rust: 1.26.0 # first release on which our doc tests pass
+    - rust: 1.15.0
+    - rust: 1.31.0
     - rust: stable
     - rust: beta
     - rust: nightly

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ followed by
 
 ```rust
 extern crate proc_macro;
-extern crate proc_macro2;
 
 #[proc_macro_derive(MyDerive)]
 pub fn my_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -733,9 +733,7 @@ impl fmt::Debug for Punct {
 /// A span must be provided explicitly which governs the name resolution
 /// behavior of the resulting identifier.
 ///
-/// ```rust
-/// extern crate proc_macro2;
-///
+/// ```edition2018
 /// use proc_macro2::{Ident, Span};
 ///
 /// fn main() {
@@ -747,13 +745,9 @@ impl fmt::Debug for Punct {
 ///
 /// An ident can be interpolated into a token stream using the `quote!` macro.
 ///
-/// ```rust
-/// #[macro_use]
-/// extern crate quote;
-///
-/// extern crate proc_macro2;
-///
+/// ```edition2018
 /// use proc_macro2::{Ident, Span};
+/// use quote::quote;
 ///
 /// fn main() {
 ///     let ident = Ident::new("demo", Span::call_site());
@@ -770,9 +764,7 @@ impl fmt::Debug for Punct {
 /// A string representation of the ident is available through the `to_string()`
 /// method.
 ///
-/// ```rust
-/// # extern crate proc_macro2;
-/// #
+/// ```edition2018
 /// # use proc_macro2::{Ident, Span};
 /// #
 /// # let ident = Ident::new("another_identifier", Span::call_site());


### PR DESCRIPTION
Older compilers ignore the ```` ```edition2018```` code blocks which is why we no longer need different Travis scripts for them.