### PR TITLE
Rename Span::unstable to Span::unwrap

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -24,7 +24,7 @@
 //     Enabled on rustc 1.29 only.
 //
 // "nightly"
-//     Enable the Span::unstable method. This is to support proc_macro_span and
+//     Enable the Span::unwrap method. This is to support proc_macro_span and
 //     proc_macro_diagnostic use on the nightly channel without requiring the
 //     semver exemption opt-in. Enabled when building with nightly.
 //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,8 +344,15 @@ impl Span {
     /// `proc_macro2::Span`, the `proc_macro::Span` type can only exist within
     /// the context of a procedural macro invocation.
     #[cfg(wrap_proc_macro)]
+    pub fn unwrap(self) -> proc_macro::Span {
+        self.inner.unwrap()
+    }
+
+    // Soft deprecated. Please use Span::unwrap.
+    #[cfg(wrap_proc_macro)]
+    #[doc(hidden)]
     pub fn unstable(self) -> proc_macro::Span {
-        self.inner.unstable()
+        self.unwrap()
     }
 
     /// The original source file into which this span points.

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -460,7 +460,7 @@ impl Span {
         }
     }
 
-    pub fn unstable(self) -> proc_macro::Span {
+    pub fn unwrap(self) -> proc_macro::Span {
         match self {
             Span::Compiler(s) => s,
             Span::Fallback(_) => panic!("proc_macro::Span is only available in procedural macros"),


### PR DESCRIPTION
The method is not unstable because you can call it from a procedural macro on a stable compiler. The name unwrap indicates that it panics if not present, i.e. if not inside of a proc macro like the method documentation talks about.