### PR TITLE
Derive traits for LineColumn

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,6 +301,7 @@ impl fmt::Debug for SourceFile {
 ///
 /// This type is semver exempt and not exposed by default.
 #[cfg(span_locations)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct LineColumn {
     /// The 1-indexed line in the source file on which the span starts or ends
     /// (inclusive).


### PR DESCRIPTION
Fixes #83. These derives match https://doc.rust-lang.org/nightly/proc_macro/struct.LineColumn.html.