### PR TITLE
Make TokenStream's IntoIter derive Clone

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1122,6 +1122,7 @@ pub mod token_stream {
     ///
     /// The iteration is "shallow", e.g. the iterator doesn't recurse into
     /// delimited groups, and returns whole groups as token trees.
+    #[derive(Clone)]
     pub struct IntoIter {
         inner: imp::TokenTreeIter,
         _marker: marker::PhantomData<Rc<()>>,

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -318,6 +318,7 @@ impl fmt::Debug for LexError {
     }
 }
 
+#[derive(Clone)]
 pub enum TokenTreeIter {
     Compiler(proc_macro::token_stream::IntoIter),
     Fallback(fallback::TokenTreeIter),


### PR DESCRIPTION
Both the wrapper and fallback versions are cloneable.
This brings proc_macro2 in line with proc_macro in terms of this
functionality.