### PR TITLE
Actually allow disabling proc-macro feature in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
     - rust: nightly
       script:
         - cargo test
-        - cargo test --no-default-features
+        - cargo test --no-default-features -- --ignored # run the ignored test to make sure the `proc-macro` feature is disabled
         - cargo test --features span-locations
         - RUSTFLAGS='--cfg procmacro2_semver_exempt' cargo test
         - RUSTFLAGS='--cfg procmacro2_semver_exempt' cargo test --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ rustdoc-args = ["--cfg", "procmacro2_semver_exempt"]
 unicode-xid = "0.2"
 
 [dev-dependencies]
-quote = "1.0"
+quote = { version = "1.0", default_features = false }
 
 [features]
 proc-macro = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@
 //! # const IGNORE: &str = stringify! {
 //! #[proc_macro_derive(MyDerive)]
 //! # };
+//! # #[cfg(wrap_proc_macro)]
 //! pub fn my_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 //!     let input = proc_macro2::TokenStream::from(input);
 //!

--- a/tests/features.rs
+++ b/tests/features.rs
@@ -1,0 +1,4 @@
+#[test] #[ignore]
+fn make_sure_no_proc_macro() {
+    assert!(!cfg!(feature = "proc-macro"), "still compiled with proc_macro?");
+}


### PR DESCRIPTION
I was working on a separate PR when I noticed that adding `--no-default-features` to `cargo test` didn't actually disable the `proc-macro` feature. Turns out the `quote` dev-dependency was sneakily reactivating that feature through its own default feature.

When I fixed that, one of the doc tests failed to compile, so I fixed that as well.

I also added an `#[ignore]`'d test that asserts that `proc-macro` is disabled, and told travis to run that test when using `--no-default-features`. That's a little wacky but it's the best way I can think of to prevent this happening again.