### PR TITLE
Make all types `Send` and `Sync` if the "proc-macro" feature is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,17 @@ reminder that you are outside of the normal semver guarantees.
 
 Semver exempt methods are marked as such in the proc-macro2 documentation.
 
+## Thread-Safety.
+
+By default, most of `proc_macro2`'s types are not `Send` or `Sync` -- they cannot be sent or shared between threads. This is because `proc_macro2` wraps `proc_macro`, which internally uses thread-unsafe data structures to represent token streams. However, if you don't need `proc_macro` compatibility, you can disable the `proc-macro` feature in your `Cargo.toml` like so:
+
+```toml
+[dependencies]
+proc-macro2 = { version = "[...]", default_features = false }
+```
+
+This will remove the dependency on `proc_macro`. In versions of `proc-macro2` starting from `1.1.0`, this will also make all proc_macro2 data structures thread safe. (Make sure you disable the `proc-macro` feature in any other crates that depend on `proc_macro2`, though, so that they don't reactivate the feature.)
+
 <br>
 
 #### License

--- a/tests/marker.rs
+++ b/tests/marker.rs
@@ -40,14 +40,35 @@ macro_rules! assert_impl {
 assert_impl!(Delimiter is Send and Sync);
 assert_impl!(Spacing is Send and Sync);
 
-assert_impl!(Group is not Send or Sync);
-assert_impl!(Ident is not Send or Sync);
-assert_impl!(LexError is not Send or Sync);
-assert_impl!(Literal is not Send or Sync);
-assert_impl!(Punct is not Send or Sync);
-assert_impl!(Span is not Send or Sync);
-assert_impl!(TokenStream is not Send or Sync);
-assert_impl!(TokenTree is not Send or Sync);
+#[cfg(wrap_proc_macro)]
+mod not_send_sync_if_proc_macro {
+    use super::*;
+    #[cfg(not(feature = "proc-macro"))]
+    compile_error!();
+
+    assert_impl!(Group is not Send or Sync);
+    assert_impl!(Ident is not Send or Sync);
+    assert_impl!(LexError is not Send or Sync);
+    assert_impl!(Literal is not Send or Sync);
+    assert_impl!(Punct is not Send or Sync);
+    assert_impl!(Span is not Send or Sync);
+    assert_impl!(TokenStream is not Send or Sync);
+    assert_impl!(TokenTree is not Send or Sync);
+}
+
+#[cfg(not(wrap_proc_macro))]
+mod send_sync_if_not_proc_macro {
+    use super::*;
+
+    assert_impl!(Group is Send and Sync);
+    assert_impl!(Ident is Send and Sync);
+    assert_impl!(LexError is Send and Sync);
+    assert_impl!(Literal is Send and Sync);
+    assert_impl!(Punct is Send and Sync);
+    assert_impl!(Span is Send and Sync);
+    assert_impl!(TokenStream is Send and Sync);
+    assert_impl!(TokenTree is Send and Sync);
+}
 
 #[cfg(procmacro2_semver_exempt)]
 mod semver_exempt {


### PR DESCRIPTION
## Summary
Makes all types `Send` and `Sync` if the "proc-macro" feature is disabled.

## Motivation
One of my side-projects uses `syn` to parse big swathes of rust code. I'd like to speed things up using `rayon` to parallelize operations on the resulting syntax trees. Unfortunately, most `syn` data structures arent `Send` or `Sync`. This is because they include `proc-macro2` datastructures, which aren't `Send` or `Sync`, due to the fact that they possibly wrap `proc-macro` datastructures.

However, I don't need `proc-macro` compatibility, so for my use case that's a pointless constraint; the fallback implementation of `proc-macro2` is fully threadsafe, but the code includes markers telling my code that it isn't. So I'm stuck serial. I believe I've seen discussions of similar issues somewhere, maybe the rust-analyzer issues tracker? I don't have any links to hand unfortunately.

This change fixes that by making things `Send` and `Sync` when the `proc-macro` feature is disabled. It also adds docs and tests.

This isn't a breaking change because it's just adding trait implementations.

## Drawbacks
This might confuse people who expect proc-macro2 to always support Send and Sync (instead of only when default features are enabled.)

If the crate later wants to implement copy-on-write optimizations similar to proc-macro, it'll have to use `Arc<RwLock<...>>` instead of `Rc<RefCell<...>>`.

## Alternatives
Don't merge this. I can always use a patched version of `syn` / `proc_macro2` if i've really gotta.