### PR TITLE
Fix cfg checks when compiled with `--target`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ matrix:
       name: WebAssembly
       install: rustup target add wasm32-unknown-unknown
       script: cargo test --target wasm32-unknown-unknown --no-run
+    - rust: nightly-2019-12-19
+      name: docs.rs
+      script: RUSTDOCFLAGS='--cfg procmacro2_semver_exempt' RUSTFLAGS='--cfg procmacro2_semver_exempt' cargo doc --target x86_64-unknown-linux-gnu
 
 before_script:
   - set -o errexit

--- a/build.rs
+++ b/build.rs
@@ -47,13 +47,13 @@ fn main() {
         process::exit(1);
     }
 
-    let semver_exempt = cfg!(procmacro2_semver_exempt);
+    let semver_exempt = env::var("CARGO_CFG_PROCMACRO2_SEMVER_EXEMPT").is_ok();
     if semver_exempt {
         // https://github.com/alexcrichton/proc-macro2/issues/147
         println!("cargo:rustc-cfg=procmacro2_semver_exempt");
     }
 
-    if semver_exempt || cfg!(feature = "span-locations") {
+    if semver_exempt || env::var("CARGO_FEATURE_SPAN_LOCATIONS").is_ok() {
         println!("cargo:rustc-cfg=span_locations");
     }
 
@@ -84,7 +84,7 @@ fn enable_use_proc_macro(target: &str) -> bool {
     }
 
     // Otherwise, only enable it if our feature is actually enabled.
-    cfg!(feature = "proc-macro")
+    env::var("CARGO_FEATURE_PROC_MACRO").is_ok()
 }
 
 struct RustcVersion {


### PR DESCRIPTION
Hi,
Since the docs.rs update[1] the docs here don't compile.[2]
it seems like this is happening because now the build command also pass `--target x86_64-unknown-linux-gnu` which makes the conditional compilations in the build script not work correctly.

From the cargo reference[3] it seems like the solution is to use the environment variable `CARGO_CFG_<cfg>` instead of the `cfg` macro.

This PR does it and adds to travis a test that mimics the docs.rs configuration [4]

If this somehow a bug and not a feature in cargo or something I'm missing would love to know :)


[1] https://blog.rust-lang.org/2019/09/18/upcoming-docsrs-changes.html
[2] https://docs.rs/crate/proc-macro2/1.0.6/builds
[3] https://doc.rust-lang.org/cargo/reference/environment-variables.html
[4] https://docs.rs/about 