### PR TITLE
Don't escape_default all non-ascii text

### DIFF
--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -754,10 +754,10 @@ impl Literal {
         text.push('"');
         for c in t.chars() {
             if c == '\'' {
-                // escape_default turns this into "\'" which is unnecessary.
+                // escape_debug turns this into "\'" which is unnecessary.
                 text.push(c);
             } else {
-                text.extend(c.escape_default());
+                text.extend(c.escape_debug());
             }
         }
         text.push('"');
@@ -768,10 +768,10 @@ impl Literal {
         let mut text = String::new();
         text.push('\'');
         if t == '"' {
-            // escape_default turns this into '\"' which is unnecessary.
+            // escape_debug turns this into '\"' which is unnecessary.
             text.push(t);
         } else {
-            text.extend(t.escape_default());
+            text.extend(t.escape_debug());
         }
         text.push('\'');
         Literal::_new(text)


### PR DESCRIPTION
Using escape_debug instead of escape_default matches the behavior of libproc_macro for:

```rust
println!("{:#?}", "///こんにちは世界".parse::<TokenStream>().unwrap());
```

Before: `"\u{3053}\u{3093}\u{306b}\u{3061}\u{306f}\u{4e16}\u{754c}"`
After: `"こんにちは世界"`

Fixes https://github.com/dtolnay/syn/issues/772.