### PR TITLE
Avoid unnecessary escapes for string and character literal

### DIFF
--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -753,11 +753,10 @@ impl Literal {
         let mut text = String::with_capacity(t.len() + 2);
         text.push('"');
         for c in t.chars() {
-            if c == '\'' {
-                // escape_debug turns this into "\'" which is unnecessary.
-                text.push(c);
-            } else {
-                text.extend(c.escape_debug());
+            match c {
+                // escape_debug turns these into escaped like "\'" which is unnecessary.
+                '\'' | '\\' | '\t' | '\r' | '\n' => text.push(c),
+                _ => text.extend(c.escape_debug()),
             }
         }
         text.push('"');
@@ -767,11 +766,10 @@ impl Literal {
     pub fn character(t: char) -> Literal {
         let mut text = String::new();
         text.push('\'');
-        if t == '"' {
-            // escape_debug turns this into '\"' which is unnecessary.
-            text.push(t);
-        } else {
-            text.extend(t.escape_debug());
+        match t {
+            // escape_debug turns these into escaped like '\"' which is unnecessary.
+            '"' | '\\' | '\t' | '\r' | '\n' => text.push(t),
+            _ => text.extend(t.escape_debug()),
         }
         text.push('\'');
         Literal::_new(text)

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -82,6 +82,10 @@ fn literal_string() {
     assert_eq!(Literal::string("foo").to_string(), "\"foo\"");
     assert_eq!(Literal::string("\"").to_string(), "\"\\\"\"");
     assert_eq!(Literal::string("didn't").to_string(), "\"didn't\"");
+    assert_eq!(Literal::string("foo\\bar").to_string(), "\"foo\\bar\"");
+    assert_eq!(Literal::string("foo\nbar").to_string(), "\"foo\nbar\"");
+    assert_eq!(Literal::string("foo\tbar").to_string(), "\"foo\tbar\"");
+    assert_eq!(Literal::string("foo\rbar").to_string(), "\"foo\rbar\"");
 }
 
 #[test]
@@ -89,6 +93,10 @@ fn literal_character() {
     assert_eq!(Literal::character('x').to_string(), "'x'");
     assert_eq!(Literal::character('\'').to_string(), "'\\''");
     assert_eq!(Literal::character('"').to_string(), "'\"'");
+    assert_eq!(Literal::character('\\').to_string(), "'\\'");
+    assert_eq!(Literal::character('\n').to_string(), "'\n'");
+    assert_eq!(Literal::character('\t').to_string(), "'\t'");
+    assert_eq!(Literal::character('\r').to_string(), "'\r'");
 }
 
 #[test]


### PR DESCRIPTION
String and character literals containing backslash, tab etc. are turned into escaped duplicately. 

Examples for the current behavior:

```rust
//                                          vv intended to be single backslash
assert_eq!(proc_macro2::Literal::string("foo\\bar").to_string(), "\"foo\\\\bar\"");
//                                            doubled unexpectedly...  ^^^^

assert_eq!(proc_macro2::Literal::character('\n').to_string(), "'\\n'");                                                      
```

Desirable behavior:

```rust
assert_eq!(proc_macro2::Literal::string("foo\\bar").to_string(), "\"foo\\bar\"");
assert_eq!(proc_macro2::Literal::character('\n').to_string(), "'\n'");
```

This PR fixes it.
