### PR TITLE
Add a way to force fallback implementation

### DIFF
--- a/src/detection.rs
+++ b/src/detection.rs
@@ -16,6 +16,14 @@ pub(crate) fn inside_proc_macro() -> bool {
     inside_proc_macro()
 }
 
+pub(crate) fn force_fallback() {
+    WORKS.store(1, Ordering::SeqCst);
+}
+
+pub(crate) fn unforce_fallback() {
+    initialize();
+}
+
 // Swap in a null panic hook to avoid printing "thread panicked" to stderr,
 // then use catch_unwind to determine whether the compiler's proc_macro is
 // working. When proc-macro2 is used from outside of a procedural macro all

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -14,6 +14,18 @@ use std::str::FromStr;
 use std::vec;
 use unicode_xid::UnicodeXID;
 
+/// Force use of proc-macro2's fallback implementation of the API for now, even
+/// if the compiler's implementation is available.
+pub fn force() {
+    crate::detection::force_fallback();
+}
+
+/// Resume using the compiler's implementation of the proc macro API if it is
+/// available.
+pub fn unforce() {
+    crate::detection::unforce_fallback();
+}
+
 #[derive(Clone)]
 pub(crate) struct TokenStream {
     inner: Vec<TokenTree>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,11 @@ use std::str::FromStr;
 mod detection;
 #[macro_use]
 mod strnom;
-mod fallback;
+
+// Public for proc_macro2::fallback::force() and unforce(), but those are quite
+// a niche use case so we omit it from rustdoc.
+#[doc(hidden)]
+pub mod fallback;
 
 #[cfg(not(wrap_proc_macro))]
 use crate::fallback as imp;


### PR DESCRIPTION
This adds a function `proc_macro2::fallback::force()` to force use of proc-macro2's fallback implementation of the API beginning at that point, even if the compiler's implementation is available, and a function `proc_macro2::fallback::unforce()` to resume using the compiler's implementation of the proc macro API if available.

Closes #216. Closes #219.