### PR TITLE
Add Span::range_in_file

### DIFF
--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -421,6 +421,17 @@ impl Span {
         })
     }
 
+    #[cfg(span_locations)]
+    pub fn range_in_file(&self) -> (usize, usize){
+        SOURCE_MAP.with(|cm| {
+            let cm = cm.borrow();
+            let fi = cm.fileinfo(*self);
+            let lo = fi.span.lo;
+
+            ((self.lo - lo) as usize, (self.hi - lo) as usize)
+        })
+    }
+
     #[cfg(not(span_locations))]
     pub fn join(&self, _other: Span) -> Option<Span> {
         Some(Span {})

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -423,6 +423,16 @@ impl Span {
         LineColumn { line, column }
     }
 
+    /// Get lower and upper limits in the file, real or not, for this span.
+    ///
+    /// Without fallback get (0, 0)
+    ///
+    /// This method requires the `"span-locations"` feature to be enabled.
+    #[cfg(span_locations)]
+    pub fn range_in_file(&self) -> (usize, usize) {
+        self.inner.range_in_file()
+    }
+
     /// Create a new span encompassing `self` and `other`.
     ///
     /// Returns `None` if `self` and `other` are from different files.

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -452,6 +452,15 @@ impl Span {
         }
     }
 
+    #[cfg(any(super_unstable, feature = "span-locations"))]
+    pub fn range_in_file(&self) -> (usize, usize) {
+        match self {
+            // TODO: it's impossible without rustc impl
+            Span::Compiler(_) => (0, 0),
+            Span::Fallback(s) => s.range_in_file(),
+        }
+    }
+
     pub fn join(&self, other: Span) -> Option<Span> {
         let ret = match (self, other) {
             #[cfg(proc_macro_span)]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -217,6 +217,22 @@ testing 123
     );
 }
 
+#[cfg(all(span_locations, wrap_proc_macro))]
+#[test]
+fn span_range() {
+    proc_macro2::fallback::force();
+    let source1 = "aaa\nbbb"
+        .parse::<TokenStream>()
+        .unwrap()
+        .into_iter()
+        .collect::<Vec<_>>();
+    assert_eq!(source1[0].span().end().column, 3);
+    assert_eq!(source1[0].span().range_in_file(), (0, 3));
+    assert_eq!(source1[1].span().end().column, 3);
+    assert_eq!(source1[1].span().range_in_file(), (4, 7));
+    proc_macro2::fallback::unforce();
+}
+
 #[cfg(procmacro2_semver_exempt)]
 #[cfg(not(nightly))]
 #[test]


### PR DESCRIPTION
Something like that would also be very good for me. But at the moment there is no possibility to implement it with proc_macro. 
It would allow to build adapters to other implementations of Span since the current one of LineColumn is very annoying to use.
I don't know what you think?