### PR TITLE
Add `Span::mixed_site`, `Span::resolved_at`, and `Span::located_at` behind `hygiene` feature

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -57,6 +57,10 @@ fn main() {
         println!("cargo:rustc-cfg=span_locations");
     }
 
+    if version.minor >= 45 {
+        println!("cargo:rustc-cfg=hygiene");
+    }
+
     let target = env::var("TARGET").unwrap();
     if !enable_use_proc_macro(&target) {
         return;

--- a/build.rs
+++ b/build.rs
@@ -14,6 +14,10 @@
 //     procmacro2_semver_exempt surface area is implemented by using the
 //     nightly-only proc_macro API.
 //
+//  "hygiene"
+//    Enable Span::mixed_site() and non-dummy behavior of Span::resolved_at
+//    and Span::located_at. Enabled on Rust 1.45+.
+//
 // "proc_macro_span"
 //     Enable non-dummy behavior of Span::start and Span::end methods which
 //     requires an unstable compiler feature. Enabled when building with

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -384,17 +384,12 @@ impl Span {
         Span::call_site()
     }
 
-    #[cfg(procmacro2_semver_exempt)]
-    pub fn resolved_at(&self, _other: Span) -> Span {
-        // Stable spans consist only of line/column information, so
-        // `resolved_at` and `located_at` only select which span the
-        // caller wants line/column information from.
-        *self
+    pub fn resolved_at(&self, other: Span) -> Span {
+        other
     }
 
-    #[cfg(procmacro2_semver_exempt)]
-    pub fn located_at(&self, other: Span) -> Span {
-        other
+    pub fn located_at(&self, _other: Span) -> Span {
+        *self
     }
 
     #[cfg(procmacro2_semver_exempt)]

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -374,6 +374,11 @@ impl Span {
         Span { lo: 0, hi: 0 }
     }
 
+    #[cfg(hygiene)]
+    pub fn mixed_site() -> Span {
+        Span::call_site()
+    }
+
     #[cfg(procmacro2_semver_exempt)]
     pub fn def_site() -> Span {
         Span::call_site()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,6 +348,16 @@ impl Span {
         Span::_new(imp::Span::call_site())
     }
 
+    /// The span located at the invocation of the procedural macro, but with
+    /// local variables, labels, and `$crate` resolved at the definition site
+    /// of the macro. This is the same hygiene behavior as `macro_rules`.
+    ///
+    /// This function requires Rust 1.45 or later.
+    #[cfg(hygiene)]
+    pub fn mixed_site() -> Span {
+        Span::_new(imp::Span::mixed_site())
+    }
+
     /// A span that resolves at the macro definition site.
     ///
     /// This method is semver exempt and not exposed by default.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -369,8 +369,8 @@ impl Span {
     /// Creates a new span with the same line/column information as `self` but
     /// that resolves symbols as though it were at `other`.
     ///
-    /// This method is semver exempt and not exposed by default.
-    #[cfg(procmacro2_semver_exempt)]
+    /// On versions of Rust prior to 1.45, this returns `other` to preserve the
+    /// name resolution behavior while discarding location information.
     pub fn resolved_at(&self, other: Span) -> Span {
         Span::_new(self.inner.resolved_at(other.inner))
     }
@@ -378,8 +378,8 @@ impl Span {
     /// Creates a new span with the same name resolution behavior as `self` but
     /// with the line/column information of `other`.
     ///
-    /// This method is semver exempt and not exposed by default.
-    #[cfg(procmacro2_semver_exempt)]
+    /// On versions of Rust prior to 1.45, this returns `self` to preserve the
+    /// name resolution behavior while discarding location information.
     pub fn located_at(&self, other: Span) -> Span {
         Span::_new(self.inner.located_at(other.inner))
     }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -376,6 +376,15 @@ impl Span {
         }
     }
 
+    #[cfg(hygiene)]
+    pub fn mixed_site() -> Span {
+        if inside_proc_macro() {
+            Span::Compiler(proc_macro::Span::mixed_site())
+        } else {
+            Span::Fallback(fallback::Span::mixed_site())
+        }
+    }
+
     #[cfg(super_unstable)]
     pub fn def_site() -> Span {
         if inside_proc_macro() {

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -394,19 +394,29 @@ impl Span {
         }
     }
 
-    #[cfg(super_unstable)]
     pub fn resolved_at(&self, other: Span) -> Span {
         match (self, other) {
+            #[cfg(hygiene)]
             (Span::Compiler(a), Span::Compiler(b)) => Span::Compiler(a.resolved_at(b)),
+
+            // Name resolution affects semantics, but location is only cosmetic
+            #[cfg(not(hygiene))]
+            (Span::Compiler(_), Span::Compiler(_)) => other,
+
             (Span::Fallback(a), Span::Fallback(b)) => Span::Fallback(a.resolved_at(b)),
             _ => mismatch(),
         }
     }
 
-    #[cfg(super_unstable)]
     pub fn located_at(&self, other: Span) -> Span {
         match (self, other) {
+            #[cfg(hygiene)]
             (Span::Compiler(a), Span::Compiler(b)) => Span::Compiler(a.located_at(b)),
+
+            // Name resolution affects semantics, but location is only cosmetic
+            #[cfg(not(hygiene))]
+            (Span::Compiler(_), Span::Compiler(_)) => *self,
+
             (Span::Fallback(a), Span::Fallback(b)) => Span::Fallback(a.located_at(b)),
             _ => mismatch(),
         }


### PR DESCRIPTION
This adds support for hygiene-related APIs recently stabilized for Rust 1.45 (currently nightly).

  * `mixed_site` was stabilized in https://github.com/rust-lang/rust/pull/68716.
  * `resolved_at` and `located_at` were stabilized in https://github.com/rust-lang/rust/pull/69041

The Cargo feature is named following the overarching `proc_macro_hygiene` language feature [also about to be stabilized](https://github.com/rust-lang/rust/pull/68717), which itself doesn't add any API surface for `proc_macro2`. 

Closes #210 