### PR TITLE
Eliminate recursion from token stream parser

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -160,7 +160,15 @@ pub(crate) fn token_stream(mut input: Cursor) -> PResult<TokenStream> {
             continue;
         }
 
-        if let Ok((rest, tt)) = token_tree(input) {
+        #[cfg(span_locations)]
+        let lo = input.off;
+        if let Ok((rest, mut tt)) = token_kind(input) {
+            tt.set_span(crate::Span::_new_stable(Span {
+                #[cfg(span_locations)]
+                lo,
+                #[cfg(span_locations)]
+                hi: rest.off,
+            }));
             trees.push(tt);
             input = rest;
             continue;
@@ -170,19 +178,6 @@ pub(crate) fn token_stream(mut input: Cursor) -> PResult<TokenStream> {
     }
 
     Ok((input, TokenStream { inner: trees }))
-}
-
-fn token_tree(input: Cursor) -> PResult<TokenTree> {
-    #[cfg(span_locations)]
-    let lo = input.off;
-    let (rest, mut tt) = token_kind(input)?;
-    tt.set_span(crate::Span::_new_stable(Span {
-        #[cfg(span_locations)]
-        lo,
-        #[cfg(span_locations)]
-        hi: rest.off,
-    }));
-    Ok((rest, tt))
 }
 
 fn token_kind(input: Cursor) -> PResult<TokenTree> {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -172,24 +172,21 @@ pub(crate) fn token_stream(mut input: Cursor) -> PResult<TokenStream> {
     Ok((input, TokenStream { inner: trees }))
 }
 
-#[cfg(not(span_locations))]
 fn spanned<'a, T>(
     input: Cursor<'a>,
     f: fn(Cursor<'a>) -> PResult<'a, T>,
 ) -> PResult<'a, (T, crate::Span)> {
-    let (a, b) = f(input)?;
-    Ok((a, ((b, crate::Span::_new_stable(Span::call_site())))))
-}
-
-#[cfg(span_locations)]
-fn spanned<'a, T>(
-    input: Cursor<'a>,
-    f: fn(Cursor<'a>) -> PResult<'a, T>,
-) -> PResult<'a, (T, crate::Span)> {
+    #[cfg(span_locations)]
     let lo = input.off;
     let (a, b) = f(input)?;
+    #[cfg(span_locations)]
     let hi = a.off;
-    let span = crate::Span::_new_stable(Span { lo, hi });
+    let span = crate::Span::_new_stable(Span {
+        #[cfg(span_locations)]
+        lo,
+        #[cfg(span_locations)]
+        hi,
+    });
     Ok((a, (b, span)))
 }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -150,22 +150,25 @@ fn word_break(input: Cursor) -> Result<Cursor, LexError> {
 
 pub(crate) fn token_stream(mut input: Cursor) -> PResult<TokenStream> {
     let mut trees = Vec::new();
+
     loop {
         input = skip_whitespace(input);
-        match doc_comment(input) {
-            Ok((a, tt)) => {
-                trees.extend(tt);
-                input = a;
-            }
-            Err(_) => match token_tree(input) {
-                Ok((a, tt)) => {
-                    trees.push(tt);
-                    input = a;
-                }
-                Err(_) => break,
-            },
+
+        if let Ok((rest, tt)) = doc_comment(input) {
+            trees.extend(tt);
+            input = rest;
+            continue;
         }
+
+        if let Ok((rest, tt)) = token_tree(input) {
+            trees.push(tt);
+            input = rest;
+            continue;
+        }
+
+        break;
     }
+
     Ok((input, TokenStream { inner: trees }))
 }
 


### PR DESCRIPTION
This implementation is about 14% faster on a representative source file (I used https://github.com/rust-lang/rust/blob/2c462a2f776b899d46743b1b44eda976e846e61d/src/libcore/str/mod.rs) and also makes fuzzing easier because we no longer overflow the stack.