### PR TITLE
Don't gate force/unforce on wrap_proc_macro

### DIFF
--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -17,15 +17,15 @@ use unicode_xid::UnicodeXID;
 
 /// Force use of proc-macro2's fallback implementation of the API for now, even
 /// if the compiler's implementation is available.
-#[cfg(wrap_proc_macro)]
 pub fn force() {
+    #[cfg(wrap_proc_macro)]
     crate::detection::force_fallback();
 }
 
 /// Resume using the compiler's implementation of the proc macro API if it is
 /// available.
-#[cfg(wrap_proc_macro)]
 pub fn unforce() {
+    #[cfg(wrap_proc_macro)]
     crate::detection::unforce_fallback();
 }
 


### PR DESCRIPTION
This allows a non-macro tool that uses `proc-macro2 = { default-features = false }` to contain an unconditional call to `proc_macro2::fallback::force()` (#220). Previously, such a tool would either need to not use `default-features = false`, or not use `proc_macro2::fallback::force()` and hope that nothing else in the dependency graph enables proc-macro2's default feature.