### PR TITLE
Improve debug mode perf of proc_macro wrapper

### DIFF
--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -206,14 +206,15 @@ impl FromIterator<TokenStream> for TokenStream {
 }
 
 impl Extend<TokenTree> for TokenStream {
-    fn extend<I: IntoIterator<Item = TokenTree>>(&mut self, streams: I) {
+    fn extend<I: IntoIterator<Item = TokenTree>>(&mut self, stream: I) {
         match self {
             TokenStream::Compiler(tts) => {
                 // Here is the reason for DeferredTokenStream.
-                tts.extra
-                    .extend(streams.into_iter().map(into_compiler_token));
+                for token in stream {
+                    tts.extra.push(into_compiler_token(token));
+                }
             }
-            TokenStream::Fallback(tts) => tts.extend(streams),
+            TokenStream::Fallback(tts) => tts.extend(stream),
         }
     }
 }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -46,7 +46,12 @@ impl DeferredTokenStream {
     }
 
     fn evaluate_now(&mut self) {
-        self.stream.extend(self.extra.drain(..));
+        // If-check provides a fast short circuit for the common case of `extra`
+        // being empty, which saves a round trip over the proc macro bridge.
+        // Improves macro expansion time in winrt by 6% in debug mode.
+        if !self.extra.is_empty() {
+            self.stream.extend(self.extra.drain(..));
+        }
     }
 
     fn into_token_stream(mut self) -> proc_macro::TokenStream {


### PR DESCRIPTION
I dropped the following code (below; extracted from https://github.com/rylev/winrt-profile) into a dummy proc macro crate to measure the impact on winrt's code generation.

Basically it seems there are two things it's sensitive to:

- Reducing the number of calls over the proc macro bridge (roughly: number of times anything in real proc_macro gets called) can significantly improve performance.
- Reducing various overheads in the proc-macro2 wrapper layer can significantly improve performance.

This PR includes two commits, one of each type. There are certainly more of each left to do. So far in total this improves expansion time by 10%.

---

```rust
use proc_macro2::TokenStream;
use std::fs;
use std::time::Instant;
use winrt_gen::{NamespaceTypes, TypeLimit, TypeLimits, TypeReader, TypeStage, WinmdFile};

let mut paths = Vec::new();
for f in fs::read_dir("winmds").unwrap() {
    let path = f.unwrap().path();
    paths.push(WinmdFile::new(path));
}
let begin = Instant::now();
let reader = TypeReader::new(paths);
let mut limits = TypeLimits::new(&reader);
let types = NamespaceTypes {
    namespace: "windows.ui.xaml".into(),
    limit: TypeLimit::All,
};
limits.insert(types).unwrap();
let stage = TypeStage::from_limits(&reader, &limits);
let tree = stage.into_tree();
let out: TokenStream = tree.to_tokens().collect();
println!("ELAPSED: {:?}", begin.elapsed());
```

Ref https://github.com/dtolnay/quote/issues/160