### PR TITLE
Remove procmacro2_semver_exempt feature gate on all methods stabilized in rustc 1.45

### DIFF
--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -426,7 +426,6 @@ impl Span {
         Span { lo: 0, hi: 0 }
     }
 
-    #[cfg(procmacro2_semver_exempt)]
     #[cfg(hygiene)]
     pub fn mixed_site() -> Span {
         Span::call_site()
@@ -437,7 +436,6 @@ impl Span {
         Span::call_site()
     }
 
-    #[cfg(procmacro2_semver_exempt)]
     pub fn resolved_at(&self, _other: Span) -> Span {
         // Stable spans consist only of line/column information, so
         // `resolved_at` and `located_at` only select which span the
@@ -445,7 +443,6 @@ impl Span {
         *self
     }
 
-    #[cfg(procmacro2_semver_exempt)]
     pub fn located_at(&self, other: Span) -> Span {
         other
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -370,7 +370,6 @@ impl Span {
     /// of the macro. This is the same hygiene behavior as `macro_rules`.
     ///
     /// This function requires Rust 1.45 or later.
-    #[cfg(procmacro2_semver_exempt)]
     #[cfg(hygiene)]
     pub fn mixed_site() -> Span {
         Span::_new(imp::Span::mixed_site())
@@ -386,14 +385,12 @@ impl Span {
 
     /// Creates a new span with the same line/column information as `self` but
     /// that resolves symbols as though it were at `other`.
-    #[cfg(procmacro2_semver_exempt)]
     pub fn resolved_at(&self, other: Span) -> Span {
         Span::_new(self.inner.resolved_at(other.inner))
     }
 
     /// Creates a new span with the same name resolution behavior as `self` but
     /// with the line/column information of `other`.
-    #[cfg(procmacro2_semver_exempt)]
     pub fn located_at(&self, other: Span) -> Span {
         Span::_new(self.inner.located_at(other.inner))
     }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -382,7 +382,6 @@ impl Span {
         }
     }
 
-    #[cfg(procmacro2_semver_exempt)]
     #[cfg(hygiene)]
     pub fn mixed_site() -> Span {
         if inside_proc_macro() {
@@ -401,7 +400,6 @@ impl Span {
         }
     }
 
-    #[cfg(procmacro2_semver_exempt)]
     pub fn resolved_at(&self, other: Span) -> Span {
         match (self, other) {
             #[cfg(hygiene)]
@@ -416,7 +414,6 @@ impl Span {
         }
     }
 
-    #[cfg(procmacro2_semver_exempt)]
     pub fn located_at(&self, other: Span) -> Span {
         match (self, other) {
             #[cfg(hygiene)]


### PR DESCRIPTION
This would resolve #241 