### PR TITLE
Parse integer suffix beginning with a hex digit

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -648,10 +648,25 @@ fn digits(mut input: Cursor) -> Result<Cursor, LexError> {
     let mut len = 0;
     let mut empty = true;
     for b in input.bytes() {
-        let digit = match b {
-            b'0'..=b'9' => (b - b'0') as u64,
-            b'a'..=b'f' => 10 + (b - b'a') as u64,
-            b'A'..=b'F' => 10 + (b - b'A') as u64,
+        match b {
+            b'0'..=b'9' => {
+                let digit = (b - b'0') as u64;
+                if digit >= base {
+                    return Err(LexError);
+                }
+            }
+            b'a'..=b'f' => {
+                let digit = 10 + (b - b'a') as u64;
+                if digit >= base {
+                    break;
+                }
+            }
+            b'A'..=b'F' => {
+                let digit = 10 + (b - b'A') as u64;
+                if digit >= base {
+                    break;
+                }
+            }
             b'_' => {
                 if empty && base == 10 {
                     return Err(LexError);
@@ -661,9 +676,6 @@ fn digits(mut input: Cursor) -> Result<Cursor, LexError> {
             }
             _ => break,
         };
-        if digit >= base {
-            return Err(LexError);
-        }
         len += 1;
         empty = false;
     }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -115,6 +115,8 @@ fn literal_suffix() {
     assert_eq!(token_count("r#\"\"#r"), 1);
     assert_eq!(token_count("'c'c"), 1);
     assert_eq!(token_count("b'b'b"), 1);
+    assert_eq!(token_count("0E"), 1);
+    assert_eq!(token_count("0o0A"), 1);
 }
 
 #[test]


### PR DESCRIPTION
Previously e.g. `0o0A` would fail to lex because `A` is not a permissible octal digit. It doesn't need to be a digit though. This is an octal literal `0o0` with suffix `A`.

This matches libproc_macro's behavior which parses it as:

```rust
Literal {
    kind: Integer,
    symbol: "0o0",
    suffix: Some("A"),
    span: #7 bytes(88..92),
}
```

https://github.com/dtolnay/syn/issues/897