### PR TITLE
Reject duplicate sign in float literal

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -591,6 +591,7 @@ fn float_digits(input: Cursor) -> Result<Cursor, LexError> {
     }
 
     if has_exp {
+        let mut has_sign = false;
         let mut has_exp_value = false;
         while let Some(&ch) = chars.peek() {
             match ch {
@@ -598,8 +599,12 @@ fn float_digits(input: Cursor) -> Result<Cursor, LexError> {
                     if has_exp_value {
                         break;
                     }
+                    if has_sign {
+                        return Err(LexError);
+                    }
                     chars.next();
                     len += 1;
+                    has_sign = true;
                 }
                 '0'..='9' => {
                     chars.next();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -117,6 +117,7 @@ fn literal_suffix() {
     assert_eq!(token_count("b'b'b"), 1);
     assert_eq!(token_count("0E"), 1);
     assert_eq!(token_count("0o0A"), 1);
+    assert_eq!(token_count("0E--0"), 4);
 }
 
 #[test]


### PR DESCRIPTION
Previously we'd just pass over as many consecutive `-`/`+` signs as the caller felt like, which is not correct. `0E--0`

https://github.com/dtolnay/syn/issues/897