### PR TITLE
Remove special case on f32/f64 suffix

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -585,8 +585,7 @@ fn float_digits(input: Cursor) -> Result<Cursor, LexError> {
         }
     }
 
-    let rest = input.advance(len);
-    if !(has_dot || has_exp || rest.starts_with("f32") || rest.starts_with("f64")) {
+    if !(has_dot || has_exp) {
         return Err(LexError);
     }
 


### PR DESCRIPTION
This had no observable effect. We'll lex the same token as an integer literal in the next branch of `literal_nocapture`.

https://github.com/alexcrichton/proc-macro2/blob/e45143b61b2da784f64ee69349db6cbb3e6f8f93/src/parse.rs#L297-L301