### PR TITLE
Parse float suffix beginning with `E`

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -590,6 +590,11 @@ fn float_digits(input: Cursor) -> Result<Cursor, LexError> {
     }
 
     if has_exp {
+        let token_before_exp = if has_dot {
+            Ok(input.advance(len - 1))
+        } else {
+            Err(LexError)
+        };
         let mut has_sign = false;
         let mut has_exp_value = false;
         while let Some(&ch) = chars.peek() {
@@ -599,7 +604,7 @@ fn float_digits(input: Cursor) -> Result<Cursor, LexError> {
                         break;
                     }
                     if has_sign {
-                        return Err(LexError);
+                        return token_before_exp;
                     }
                     chars.next();
                     len += 1;
@@ -618,7 +623,7 @@ fn float_digits(input: Cursor) -> Result<Cursor, LexError> {
             }
         }
         if !has_exp_value {
-            return Err(LexError);
+            return token_before_exp;
         }
     }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -118,6 +118,7 @@ fn literal_suffix() {
     assert_eq!(token_count("0E"), 1);
     assert_eq!(token_count("0o0A"), 1);
     assert_eq!(token_count("0E--0"), 4);
+    assert_eq!(token_count("0.0ECMA"), 1);
 }
 
 #[test]


### PR DESCRIPTION
Previously `0.0asdf` would parse as a float literal with suffix `asdf` but `0.0ECMA` would not parse as a float literal with suffix `ECMA`.