### PR TITLE
Allow only at most 6 digits in unicode escape

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -525,12 +525,21 @@ where
 {
     next_ch!(chars @ '{');
     next_ch!(chars @ '0'..='9' | 'a'..='f' | 'A'..='F');
-    loop {
-        let c = next_ch!(chars @ '0'..='9' | 'a'..='f' | 'A'..='F' | '_' | '}');
-        if c == '}' {
-            return true;
+    let mut digits = 1;
+    while let Some((_, ch)) = chars.next() {
+        match ch {
+            '}' => return true,
+            '0'..='9' | 'a'..='f' | 'A'..='F' => {
+                digits += 1;
+                if digits > 6 {
+                    return false;
+                }
+            }
+            '_' => {}
+            _ => return false,
         }
     }
+    false
 }
 
 fn float(input: Cursor) -> Result<Cursor, LexError> {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -191,6 +191,7 @@ fn fail() {
     fail("' static");
     fail("r#1");
     fail("r#_");
+    fail("\"\\u{0000000}\""); // overlong unicode escape (rust allows at most 6 hex digits)
 }
 
 #[cfg(span_locations)]


### PR DESCRIPTION
Rustc rejects unicode escapes longer than 6 digits, not including `_`.

```console
error: overlong unicode escape (must have at most 6 hex digits)
 --> src/main.rs:2:14
  |
2 |     let _ = "\u{0000000}";
  |              ^^^^^^^^^^^
```