### PR TITLE
Disallow unicode escapes that are out of range, empty, or begin with underscore

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -533,7 +533,7 @@ where
             'a'..='f' => 10 + ch as u8 - b'a',
             'A'..='F' => 10 + ch as u8 - b'A',
             '_' if len > 0 => continue,
-            '}' => return char::from_u32(value).is_some(),
+            '}' if len > 0 => return char::from_u32(value).is_some(),
             _ => return false,
         };
         if len == 6 {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -2,6 +2,7 @@ use crate::fallback::{
     is_ident_continue, is_ident_start, Group, LexError, Literal, Span, TokenStream,
 };
 use crate::{Delimiter, Punct, Spacing, TokenTree};
+use std::char;
 use std::str::{Bytes, CharIndices, Chars};
 
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -524,20 +525,23 @@ where
     I: Iterator<Item = (usize, char)>,
 {
     next_ch!(chars @ '{');
-    next_ch!(chars @ '0'..='9' | 'a'..='f' | 'A'..='F');
-    let mut digits = 1;
+    let mut value = 0;
+    let mut len = 0;
     while let Some((_, ch)) = chars.next() {
-        match ch {
-            '}' => return true,
-            '0'..='9' | 'a'..='f' | 'A'..='F' => {
-                digits += 1;
-                if digits > 6 {
-                    return false;
-                }
-            }
-            '_' => {}
+        let digit = match ch {
+            '0'..='9' => ch as u8 - b'0',
+            'a'..='f' => 10 + ch as u8 - b'a',
+            'A'..='F' => 10 + ch as u8 - b'A',
+            '_' => continue,
+            '}' => return char::from_u32(value).is_some(),
             _ => return false,
+        };
+        if len == 6 {
+            return false;
         }
+        value *= 0x10;
+        value += u32::from(digit);
+        len += 1;
     }
     false
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -532,7 +532,7 @@ where
             '0'..='9' => ch as u8 - b'0',
             'a'..='f' => 10 + ch as u8 - b'a',
             'A'..='F' => 10 + ch as u8 - b'A',
-            '_' => continue,
+            '_' if len > 0 => continue,
             '}' => return char::from_u32(value).is_some(),
             _ => return false,
         };

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -194,6 +194,7 @@ fn fail() {
     fail("\"\\u{0000000}\""); // overlong unicode escape (rust allows at most 6 hex digits)
     fail("\"\\u{999999}\""); // outside of valid range of char
     fail("\"\\u{_0}\""); // leading underscore
+    fail("\"\\u{}\""); // empty
 }
 
 #[cfg(span_locations)]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -192,6 +192,7 @@ fn fail() {
     fail("r#1");
     fail("r#_");
     fail("\"\\u{0000000}\""); // overlong unicode escape (rust allows at most 6 hex digits)
+    fail("\"\\u{999999}\""); // outside of valid range of char
 }
 
 #[cfg(span_locations)]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -193,6 +193,7 @@ fn fail() {
     fail("r#_");
     fail("\"\\u{0000000}\""); // overlong unicode escape (rust allows at most 6 hex digits)
     fail("\"\\u{999999}\""); // outside of valid range of char
+    fail("\"\\u{_0}\""); // leading underscore
 }
 
 #[cfg(span_locations)]


### PR DESCRIPTION
- ~~`"\u{999999}"`~~
- ~~`"\u{}"`~~
- ~~`"\u{_0}"`~~