### PR TITLE
Disallow bare carriage return in raw string literal

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -438,7 +438,7 @@ fn raw_string(input: Cursor) -> Result<Cursor, LexError> {
                 let rest = input.advance(i + 1 + n);
                 return Ok(literal_suffix(rest));
             }
-            '\r' => {}
+            '\r' => return Err(LexError),
             _ => {}
         }
     }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -195,6 +195,8 @@ fn fail() {
     fail("\"\\u{999999}\""); // outside of valid range of char
     fail("\"\\u{_0}\""); // leading underscore
     fail("\"\\u{}\""); // empty
+    fail("b\"\r\""); // bare carriage return in byte string
+    fail("r\"\r\""); // bare carriage return in raw string
 }
 
 #[cfg(span_locations)]


### PR DESCRIPTION
This is disallowed by rustc (though notice that the diagnostic is hilariously actually returning the carriage):

```console
error: bare CR not allowed in raw string
 --> src/main.rs:2:15
  |
";|     let s = r"
  |               ^
```