### PR TITLE
Disallow lifetime followed immediately by single quote

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -716,8 +716,11 @@ fn digits(mut input: Cursor) -> Result<Cursor, LexError> {
 fn op(input: Cursor) -> PResult<Punct> {
     match op_char(input) {
         Ok((rest, '\'')) => {
-            ident(rest)?;
-            Ok((rest, Punct::new('\'', Spacing::Joint)))
+            if ident(rest)?.0.starts_with("'") {
+                Err(LexError)
+            } else {
+                Ok((rest, Punct::new('\'', Spacing::Joint)))
+            }
         }
         Ok((rest, ch)) => {
             let kind = match op_char(rest) {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -198,6 +198,7 @@ fn fail() {
     fail("b\"\r\""); // bare carriage return in byte string
     fail("r\"\r\""); // bare carriage return in raw string
     fail("\"\\\r  \""); // backslash carriage return
+    fail("'aa'aa");
 }
 
 #[cfg(span_locations)]


### PR DESCRIPTION
This is not lexed as two consecutive lifetime tokens in Rust.

```rust
macro_rules! m {
    ($($tt:tt)*) => {};
}

m!('aa'aa);
```

```console
error: character literal may only contain one codepoint
 --> src/main.rs:5:4
  |
5 | m!('aa'aa);
  |    ^^^^
  |
help: if you meant to write a `str` literal, use double quotes
  |
5 | m!("aa"aa);
  |    ^^^^
```