### PR TITLE
Adding forbid unsafe_code

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -33,6 +33,7 @@
 //     location of a token. Enabled by procmacro2_semver_exempt or the
 //     "span-locations" Cargo cfg. This is behind a cfg because tracking
 //     location inside spans is a performance hit.
+#![forbid(unsafe_code)]
 
 use std::env;
 use std::process::{self, Command};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,7 @@
 #![cfg_attr(any(proc_macro_span, super_unstable), feature(proc_macro_span))]
 #![cfg_attr(super_unstable, feature(proc_macro_raw_ident, proc_macro_def_site))]
 #![allow(clippy::needless_doctest_main)]
+#![forbid(unsafe_code)]
 
 #[cfg(use_proc_macro)]
 extern crate proc_macro;


### PR DESCRIPTION
There is no unsafe code in this repo.
So forbidding unsafe code does not effect the code itself.
I also added it to the `build.rs` script because of an issue in Cargo Geiger, 
otherwise it will not detect that it is forbidden.