### PR TITLE
Replace ancient `op` naming

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -696,7 +696,7 @@ impl Debug for Group {
 /// `Punct` with different forms of `Spacing` returned.
 #[derive(Clone)]
 pub struct Punct {
-    op: char,
+    ch: char,
     spacing: Spacing,
     span: Span,
 }
@@ -722,9 +722,9 @@ impl Punct {
     ///
     /// The returned `Punct` will have the default span of `Span::call_site()`
     /// which can be further configured with the `set_span` method below.
-    pub fn new(op: char, spacing: Spacing) -> Punct {
+    pub fn new(ch: char, spacing: Spacing) -> Punct {
         Punct {
-            op,
+            ch,
             spacing,
             span: Span::call_site(),
         }
@@ -732,7 +732,7 @@ impl Punct {
 
     /// Returns the value of this punctuation character as `char`.
     pub fn as_char(&self) -> char {
-        self.op
+        self.ch
     }
 
     /// Returns the spacing of this punctuation character, indicating whether
@@ -759,14 +759,14 @@ impl Punct {
 /// convertible back into the same character.
 impl Display for Punct {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        Display::fmt(&self.op, f)
+        Display::fmt(&self.ch, f)
     }
 }
 
 impl Debug for Punct {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let mut debug = fmt.debug_struct("Punct");
-        debug.field("op", &self.op);
+        debug.field("char", &self.ch);
         debug.field("spacing", &self.spacing);
         imp::debug_span_field_if_nontrivial(&mut debug, self.span.inner);
         debug.finish()

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -228,7 +228,7 @@ fn leaf_token(input: Cursor) -> PResult<TokenTree> {
     if let Ok((input, l)) = literal(input) {
         // must be parsed before ident
         Ok((input, TokenTree::Literal(crate::Literal::_new_stable(l))))
-    } else if let Ok((input, p)) = op(input) {
+    } else if let Ok((input, p)) = punct(input) {
         Ok((input, TokenTree::Punct(p)))
     } else if let Ok((input, i)) = ident(input) {
         Ok((input, TokenTree::Ident(i)))
@@ -729,8 +729,8 @@ fn digits(mut input: Cursor) -> Result<Cursor, LexError> {
     }
 }
 
-fn op(input: Cursor) -> PResult<Punct> {
-    match op_char(input) {
+fn punct(input: Cursor) -> PResult<Punct> {
+    match punct_char(input) {
         Ok((rest, '\'')) => {
             if ident_any(rest)?.0.starts_with("'") {
                 Err(LexError)
@@ -739,7 +739,7 @@ fn op(input: Cursor) -> PResult<Punct> {
             }
         }
         Ok((rest, ch)) => {
-            let kind = match op_char(rest) {
+            let kind = match punct_char(rest) {
                 Ok(_) => Spacing::Joint,
                 Err(LexError) => Spacing::Alone,
             };
@@ -749,9 +749,9 @@ fn op(input: Cursor) -> PResult<Punct> {
     }
 }
 
-fn op_char(input: Cursor) -> PResult<char> {
+fn punct_char(input: Cursor) -> PResult<char> {
     if input.starts_with("//") || input.starts_with("/*") {
-        // Do not accept `/` of a comment as an op.
+        // Do not accept `/` of a comment as a punct.
         return Err(LexError);
     }
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -150,9 +150,9 @@ fn into_compiler_token(token: TokenTree) -> proc_macro::TokenTree {
                 Spacing::Joint => proc_macro::Spacing::Joint,
                 Spacing::Alone => proc_macro::Spacing::Alone,
             };
-            let mut op = proc_macro::Punct::new(tt.as_char(), spacing);
-            op.set_span(tt.span().inner.unwrap_nightly());
-            op.into()
+            let mut punct = proc_macro::Punct::new(tt.as_char(), spacing);
+            punct.set_span(tt.span().inner.unwrap_nightly());
+            punct.into()
         }
         TokenTree::Ident(tt) => tt.inner.unwrap_nightly().into(),
         TokenTree::Literal(tt) => tt.inner.unwrap_nightly().into(),

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -293,7 +293,7 @@ fn no_panic() {
 }
 
 #[test]
-fn op_before_comment() {
+fn punct_before_comment() {
     let mut tts = TokenStream::from_str("~// comment").unwrap().into_iter();
     match tts.next().unwrap() {
         TokenTree::Punct(tt) => {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -341,7 +341,7 @@ TokenStream [
                 sym: a,
             },
             Punct {
-                op: '+',
+                char: '+',
                 spacing: Alone,
             },
             Literal {
@@ -362,7 +362,7 @@ TokenStream [
                 sym: a
             },
             Punct {
-                op: '+',
+                char: '+',
                 spacing: Alone
             },
             Literal {
@@ -384,7 +384,7 @@ TokenStream [
                 span: bytes(2..3),
             },
             Punct {
-                op: '+',
+                char: '+',
                 spacing: Alone,
                 span: bytes(4..5),
             },
@@ -409,7 +409,7 @@ TokenStream [
                 span: bytes(2..3)
             },
             Punct {
-                op: '+',
+                char: '+',
                 spacing: Alone,
                 span: bytes(4..5)
             },


### PR DESCRIPTION
Op is the old name of Punct, prior to https://github.com/rust-lang/rust/pull/50473 (https://github.com/rust-lang/rust/commit/47d4089e100f6a1e19e8687158cc1e0c71ac2ae3).

This PR replaces `op` with `punct` in variable names and function names, and replaces the private `Punct::op` field with `Punct::ch` which is rendered by the Debug impl as `char`, reflecting that it's the character you get by calling as_char on the Punct.