### PR TITLE
Add forbid(unsafe_code)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@
 //! Most types in this crate are `!Sync` because the underlying compiler
 //! types make use of thread-local memory, meaning they cannot be accessed from
 //! a different thread.
+#![forbid(unsafe_code)]
 
 // Proc-macro2 types in rustdoc of other crates get linked to here.
 #![doc(html_root_url = "https://docs.rs/proc-macro2/1.0.24")]


### PR DESCRIPTION
Hi proc-macro2 Maintainers,
I am developing a safe regular expression library.  Of its dependencies, only `proc_macro2` is lacking a `forbid(unsafe_code)` declaration.  Can we please add it?

Best,
Michael

## Cargo Geiger Safety Report
```

Metric output format: x/y
    x = unsafe code used by the build
    y = total unsafe code found in the crate

Symbols: 
    🔒  = No `unsafe` usage found, declares #![forbid(unsafe_code)]
    ❓  = No `unsafe` usage found, missing #![forbid(unsafe_code)]
    ☢️  = `unsafe` usage found

Functions  Expressions  Impls  Traits  Methods  Dependency

0/0        0/0          0/0    0/0     0/0      🔒  safe-regex 0.1.0
0/0        0/0          0/0    0/0     0/0      🔒  └── safe-regex-macro 0.1.0
0/0        0/0          0/0    0/0     0/0      ❓      ├── proc-macro2 1.0.24
0/0        0/0          0/0    0/0     0/0      🔒      │   └── unicode-xid 0.2.1
0/0        0/0          0/0    0/0     0/0      🔒      └── safe-regex-compiler 0.1.0
0/0        0/0          0/0    0/0     0/0      ❓          ├── proc-macro2 1.0.24
0/0        0/0          0/0    0/0     0/0      🔒          └── quote 1.0.8
0/0        0/0          0/0    0/0     0/0      ❓              └── proc-macro2 1.0.24

0/0        0/0          0/0    0/0     0/0    

```
