### PR TITLE
Simplify token parse loop termination

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -166,7 +166,8 @@ pub(crate) fn token_stream(mut input: Cursor) -> Result<TokenStream, LexError> {
 
         let first = match input.bytes().next() {
             Some(first) => first,
-            None => break,
+            None if stack.is_empty() => return Ok(TokenStream { inner: trees }),
+            None => return Err(LexError),
         };
 
         if let Some(open_delimiter) = match first {
@@ -215,12 +216,6 @@ pub(crate) fn token_stream(mut input: Cursor) -> Result<TokenStream, LexError> {
             trees.push(tt);
             input = rest;
         }
-    }
-
-    if stack.is_empty() && input.is_empty() {
-        Ok(TokenStream { inner: trees })
-    } else {
-        Err(LexError)
     }
 }
 


### PR DESCRIPTION
There is only one single place that this loop terminates with a `break` (as opposed to `return`), and that is when the input runs out of bytes. Replace that break with returns, making it clear that there is no need for the `input.is_empty()` check at that point.