### PR TITLE
Add span to lex errors

### DIFF
--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -35,13 +35,17 @@ pub(crate) struct TokenStream {
 }
 
 #[derive(Debug)]
-pub(crate) struct LexError {}
+pub(crate) struct LexError {
+    span: Span,
+}
 
 impl LexError {
     // Codepaths that will need a meaningful span attached as part of
     // https://github.com/alexcrichton/proc-macro2/issues/178
     pub(crate) fn todo() -> Self {
-        LexError {}
+        LexError {
+            span: Span::call_site(),
+        }
     }
 }
 

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -35,7 +35,15 @@ pub(crate) struct TokenStream {
 }
 
 #[derive(Debug)]
-pub(crate) struct LexError;
+pub(crate) struct LexError {}
+
+impl LexError {
+    // Codepaths that will need a meaningful span attached as part of
+    // https://github.com/alexcrichton/proc-macro2/issues/178
+    pub(crate) fn todo() -> Self {
+        LexError {}
+    }
+}
 
 impl TokenStream {
     pub fn new() -> TokenStream {

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -36,7 +36,7 @@ pub(crate) struct TokenStream {
 
 #[derive(Debug)]
 pub(crate) struct LexError {
-    span: Span,
+    pub(crate) span: Span,
 }
 
 impl LexError {

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -40,14 +40,6 @@ pub(crate) struct LexError {
 }
 
 impl LexError {
-    // Codepaths that will need a meaningful span attached as part of
-    // https://github.com/alexcrichton/proc-macro2/issues/178
-    pub(crate) fn todo() -> Self {
-        LexError {
-            span: Span::call_site(),
-        }
-    }
-
     pub(crate) fn span(&self) -> Span {
         self.span
     }

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -47,6 +47,10 @@ impl LexError {
             span: Span::call_site(),
         }
     }
+
+    pub(crate) fn span(&self) -> Span {
+        self.span
+    }
 }
 
 impl TokenStream {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,6 +250,12 @@ impl Debug for TokenStream {
     }
 }
 
+impl LexError {
+    pub fn span(&self) -> Span {
+        Span::_new(self.inner.span())
+    }
+}
+
 impl Debug for LexError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         Debug::fmt(&self.inner, f)

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -189,8 +189,11 @@ pub(crate) fn token_stream(mut input: Cursor) -> Result<TokenStream, LexError> {
             b'}' => Some(Delimiter::Brace),
             _ => None,
         } {
+            let frame = match stack.pop() {
+                Some(frame) => frame,
+                None => return Err(lex_error(input)),
+            };
             input = input.advance(1);
-            let frame = stack.pop().ok_or_else(LexError::todo)?;
             #[cfg(span_locations)]
             let (lo, frame) = frame;
             let (open_delimiter, outer) = frame;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -209,7 +209,7 @@ pub(crate) fn token_stream(mut input: Cursor) -> Result<TokenStream, LexError> {
         } else {
             let (rest, mut tt) = match leaf_token(input) {
                 Ok((rest, tt)) => (rest, tt),
-                Err(Reject) => return Err(LexError::todo()),
+                Err(Reject) => return Err(lex_error(input)),
             };
             tt.set_span(crate::Span::_new_stable(Span {
                 #[cfg(span_locations)]
@@ -220,6 +220,19 @@ pub(crate) fn token_stream(mut input: Cursor) -> Result<TokenStream, LexError> {
             trees.push(tt);
             input = rest;
         }
+    }
+}
+
+fn lex_error(cursor: Cursor) -> LexError {
+    #[cfg(not(span_locations))]
+    let _ = cursor;
+    LexError {
+        span: Span {
+            #[cfg(span_locations)]
+            lo: cursor.off,
+            #[cfg(span_locations)]
+            hi: cursor.off,
+        },
     }
 }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -193,13 +193,13 @@ pub(crate) fn token_stream(mut input: Cursor) -> Result<TokenStream, LexError> {
                 Some(frame) => frame,
                 None => return Err(lex_error(input)),
             };
-            input = input.advance(1);
             #[cfg(span_locations)]
             let (lo, frame) = frame;
             let (open_delimiter, outer) = frame;
             if open_delimiter != close_delimiter {
-                return Err(LexError::todo());
+                return Err(lex_error(input));
             }
+            input = input.advance(1);
             let mut g = Group::new(open_delimiter, TokenStream { inner: trees });
             g.set_span(Span {
                 #[cfg(span_locations)]

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -168,7 +168,7 @@ pub(crate) fn token_stream(mut input: Cursor) -> Result<TokenStream, LexError> {
         let first = match input.bytes().next() {
             Some(first) => first,
             None if stack.is_empty() => return Ok(TokenStream { inner: trees }),
-            None => return Err(LexError),
+            None => return Err(LexError::todo()),
         };
 
         if let Some(open_delimiter) = match first {
@@ -190,12 +190,12 @@ pub(crate) fn token_stream(mut input: Cursor) -> Result<TokenStream, LexError> {
             _ => None,
         } {
             input = input.advance(1);
-            let frame = stack.pop().ok_or(LexError)?;
+            let frame = stack.pop().ok_or_else(LexError::todo)?;
             #[cfg(span_locations)]
             let (lo, frame) = frame;
             let (open_delimiter, outer) = frame;
             if open_delimiter != close_delimiter {
-                return Err(LexError);
+                return Err(LexError::todo());
             }
             let mut g = Group::new(open_delimiter, TokenStream { inner: trees });
             g.set_span(Span {
@@ -209,7 +209,7 @@ pub(crate) fn token_stream(mut input: Cursor) -> Result<TokenStream, LexError> {
         } else {
             let (rest, mut tt) = match leaf_token(input) {
                 Ok((rest, tt)) => (rest, tt),
-                Err(Reject) => return Err(LexError),
+                Err(Reject) => return Err(LexError::todo()),
             };
             tt.set_span(crate::Span::_new_stable(Span {
                 #[cfg(span_locations)]

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -108,7 +108,11 @@ impl FromStr for TokenStream {
 // Work around https://github.com/rust-lang/rust/issues/58736.
 fn proc_macro_parse(src: &str) -> Result<proc_macro::TokenStream, LexError> {
     let result = panic::catch_unwind(|| src.parse().map_err(LexError::Compiler));
-    result.unwrap_or_else(|_| Err(LexError::Fallback(fallback::LexError::todo())))
+    result.unwrap_or_else(|_| {
+        Err(LexError::Fallback(fallback::LexError {
+            span: fallback::Span::call_site(),
+        }))
+    })
 }
 
 impl Display for TokenStream {
@@ -279,7 +283,12 @@ impl Display for LexError {
             #[cfg(lexerror_display)]
             LexError::Compiler(e) => Display::fmt(e, f),
             #[cfg(not(lexerror_display))]
-            LexError::Compiler(_e) => Display::fmt(&fallback::LexError::todo(), f),
+            LexError::Compiler(_e) => Display::fmt(
+                &fallback::LexError {
+                    span: fallback::Span::call_site(),
+                },
+                f,
+            ),
             LexError::Fallback(e) => Display::fmt(e, f),
         }
     }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -243,6 +243,15 @@ impl Debug for TokenStream {
     }
 }
 
+impl LexError {
+    pub(crate) fn span(&self) -> Span {
+        match self {
+            LexError::Compiler(_) => Span::call_site(),
+            LexError::Fallback(e) => Span::Fallback(e.span()),
+        }
+    }
+}
+
 impl From<proc_macro::LexError> for LexError {
     fn from(e: proc_macro::LexError) -> LexError {
         LexError::Compiler(e)

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -107,8 +107,8 @@ impl FromStr for TokenStream {
 
 // Work around https://github.com/rust-lang/rust/issues/58736.
 fn proc_macro_parse(src: &str) -> Result<proc_macro::TokenStream, LexError> {
-    panic::catch_unwind(|| src.parse().map_err(LexError::Compiler))
-        .unwrap_or(Err(LexError::Fallback(fallback::LexError)))
+    let result = panic::catch_unwind(|| src.parse().map_err(LexError::Compiler));
+    result.unwrap_or_else(|_| Err(LexError::Fallback(fallback::LexError::todo())))
 }
 
 impl Display for TokenStream {
@@ -270,7 +270,7 @@ impl Display for LexError {
             #[cfg(lexerror_display)]
             LexError::Compiler(e) => Display::fmt(e, f),
             #[cfg(not(lexerror_display))]
-            LexError::Compiler(_e) => Display::fmt(&fallback::LexError, f),
+            LexError::Compiler(_e) => Display::fmt(&fallback::LexError::todo(), f),
             LexError::Fallback(e) => Display::fmt(e, f),
         }
     }


### PR DESCRIPTION
Closes #178.

This PR adds `impl LexError { pub fn span(&self) -> Span }`. While libproc_macro's LexError does not have such a method, having this is far more important for proc-macro2 than for libproc_macro, because proc macro input is *already lexed* by rustc and receives good rustc-generated diagnostics on lex errors, while main.rs / build.rs-based parser do not get that.

<br>

### Before

```console
  error: lex error
    ┌─ src/main.rs:1:1
    │
  1 │ //! this file contains a lex error... where?
    │ ^ lex error
```

### After

```console
  error: lex error
     ┌─ src/main.rs:46:12
     │
  46 │ fn main() {)
     │            ^ lex error
```