### PR TITLE
Use real Literal::from_str from libproc_macro

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -78,6 +78,10 @@ fn main() {
         println!("cargo:rustc-cfg=hygiene");
     }
 
+    if version.minor >= 54 {
+        println!("cargo:rustc-cfg=literal_from_str");
+    }
+
     let target = env::var("TARGET").unwrap();
     if !enable_use_proc_macro(&target) {
         return;


### PR DESCRIPTION
Closes #287 now that https://github.com/rust-lang/rust/pull/84717 has made it into a stable Rust release.